### PR TITLE
Feature SSL Cassandra deployement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ manifest.yml.OLD
 manifest.yml.POblin
 bosh-release_cassandra39_ok_26072017
 manifest.yml.OK
+cred.yml

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ manifest.yml.POblin
 bosh-release_cassandra39_ok_26072017
 manifest.yml.OK
 cred.yml
+manifest.yml.OK

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ bosh-release_cassandra39_ok_26072017
 manifest.yml.OK
 cred.yml
 manifest.yml.OK
+creds.yml
+manifest.yml.TEST
+manifest.yml.TEST2
+manifest.yml.TEST3OK
+

--- a/config/final.yml
+++ b/config/final.yml
@@ -1,5 +1,5 @@
 ---
-final_name: cassandra39-services
+final_name: cassandra39-serv_ssl
 blobstore:
   provider: s3 
   options:

--- a/jobs/cassandra_injector/spec
+++ b/jobs/cassandra_injector/spec
@@ -32,12 +32,14 @@ templates:
 #  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
 #  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
 #  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
-  ssl2/cert: config/certs/node.crt
-  ssl2/cert_ca: config/certs/ca.crt
-  ssl2/cert_private_key: config/certs/node.key
-  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
-  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
-  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
+#  ssl2/cert: config/certs/node.crt
+#  ssl2/cert_ca: config/certs/ca.crt
+#  ssl2/cert_private_key: config/certs/node.key
+#  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
+#  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
+#  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
+  ssl3/ssl_env.ctl.erb: config/certs/ssl_env.ctl
+  ssl3/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
   bin/creer_pem_cli_serv.sh: bin/creer_pem_cli_serv.sh

--- a/jobs/cassandra_injector/spec
+++ b/jobs/cassandra_injector/spec
@@ -28,7 +28,6 @@ templates:
   config/logback.xml.erb: conf/logback.xml
   config/logback-tools.xml.erb: conf/logback-tools.xml
   config/commitlog_archiving.properties.erb: conf/commitlog_archiving.properties
-  config/cqlshrc.sample.erb: conf/cqlshrc.sample
 #  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
 #  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
 #  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
@@ -38,6 +37,7 @@ templates:
 #  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
 #  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
 #  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
+  config/cqlshrc.erb: root/.cassandra/cqlshrc
   ssl3/ssl_env.ctl.erb: config/certs/ssl_env.ctl
   ssl3/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
@@ -257,4 +257,15 @@ properties:
   cassandra_injector.cass_KSP:
     default:
     description: cassandra ssl keystore passwd
-
+  cassandra_injector.validate_ssl_TF:
+    default: false
+    description: cassandra ssl validate true or false
+  cassandra_injector.server_encryption_options.internode_encryption:
+    default: false
+    description: cassandra ssl entre noeuds true or false
+  cassandra_injector.client_encryption_options.enabled:
+    default: false
+    description: cassandra ssl entre client et server true or false
+  cassandra_injector.client_encryption_options.require_client_auth:
+    default: false
+    description: cassandra ssl entre client et server et authentifi

--- a/jobs/cassandra_injector/spec
+++ b/jobs/cassandra_injector/spec
@@ -3,11 +3,15 @@ name: cassandra_injector
 packages:
 - cassandra
 - openjdk
+provides:
+- name: seeds
+  type: cassandra_injectors
 consumes:
 - name: seeds
-  type: cassandra_seeds
+  type: cassandra_injectors
+
 templates:
-  bin/cassandra_injector_ctl: bin/cassandra_injector_ctl
+  bin/cassandra_injector.ctl: bin/cassandra_injector_ctl
   bin/monit_debugger: bin/monit_debugger
   bin/node-tool.sh: bin/node-tool.sh
   bin/cql-sh.sh: bin/cql-sh.sh
@@ -28,6 +32,9 @@ templates:
   config/logback-tools.xml.erb: conf/logback-tools.xml
   config/commitlog_archiving.properties.erb: conf/commitlog_archiving.properties
   config/cqlshrc.sample.erb: conf/cqlshrc.sample
+  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
+  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
+  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
   bin/sec-sysauth.sh: bin/post-start
@@ -52,13 +59,13 @@ properties:
     default: 2
     description: nombre de thread pour gerer les hints. A augmenter si cluster multi datacenter.
   cassandra_injector.authenticator:
-    default: PasswordAuthenticator
+    default: PasswordAuthenticator 
     description: AllowAllAuthenticator c.a.d pas de controle sinon possible avec  PasswordAuthenticator.
   cassandra_injector.authorizer:
     default: CassandraAuthorizer
     description: pour gerer les droits dans la bdd. Controle fin avec CassandraAuthorizer.
   cassandra_injector.permissions_validity_in_ms:
-    default: 2000 
+    default: 4000 
     description: duree de validite des permissions stockees en cache.Se desactive en positionnant a 0 avec AllowAllAuthorizer.
   cassandra_injector.partitioner:
     default: org.apache.cassandra.dht.Murmur3Partitioner 
@@ -232,4 +239,9 @@ properties:
     description:
   cassandra_injector.cass_pwd:
     default: cassandra
-
+  cassandra_injector.cassConf_ssl:
+    default: 1
+    description: use tls/ssl for authent and transactions 
+  cassandra_injector.cassDbCertificate:
+    default: "NOT INITIALIZED"
+    description: use tls/ssl for authent and transactions 

--- a/jobs/cassandra_injector/spec
+++ b/jobs/cassandra_injector/spec
@@ -34,6 +34,7 @@ templates:
   ssl/cassandradb.pem.erb: ssl/cassandradb.pem
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
+  bin/creer_pem_cli_serv.sh: bin/creer_pem_cli_serv.sh
   bin/sec-sysauth.sh: bin/post-start
 
 properties:
@@ -236,8 +237,8 @@ properties:
     description:
   cassandra_injector.cass_pwd:
     default: cassandra
-  cassandra_injector.cassConf_ssl:
-    default: 1
+  cassandra_injector.cass_ssl_YN:
+    default: N
     description: use tls/ssl for authent and transactions 
   cassandra_injector.cassDbCertificate:
     default: "NOT INITIALIZED"

--- a/jobs/cassandra_injector/spec
+++ b/jobs/cassandra_injector/spec
@@ -29,9 +29,15 @@ templates:
   config/logback-tools.xml.erb: conf/logback-tools.xml
   config/commitlog_archiving.properties.erb: conf/commitlog_archiving.properties
   config/cqlshrc.sample.erb: conf/cqlshrc.sample
-  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
-  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
-  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
+#  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
+#  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
+#  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
+  ssl2/cert: config/certs/node.crt
+  ssl2/cert_ca: config/certs/ca.crt
+  ssl2/cert_private_key: config/certs/node.key
+  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
+  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
+  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
   bin/creer_pem_cli_serv.sh: bin/creer_pem_cli_serv.sh
@@ -243,3 +249,10 @@ properties:
   cassandra_injector.cassDbCertificate:
     default: "NOT INITIALIZED"
     description: use tls/ssl for authent and transactions 
+  cassandra_injector.cert:
+    type: certficate
+    description: cluster certificate
+  cassandra_injector.cass_KSP:
+    default:
+    description: cassandra ssl keystore passwd
+

--- a/jobs/cassandra_injector/spec
+++ b/jobs/cassandra_injector/spec
@@ -3,15 +3,12 @@ name: cassandra_injector
 packages:
 - cassandra
 - openjdk
-provides:
-- name: seeds
-  type: cassandra_injectors
 consumes:
 - name: seeds
-  type: cassandra_injectors
+  type: cassandra_seeds
 
 templates:
-  bin/cassandra_injector.ctl: bin/cassandra_injector_ctl
+  bin/cassandra_injector_ctl: bin/cassandra_injector_ctl
   bin/monit_debugger: bin/monit_debugger
   bin/node-tool.sh: bin/node-tool.sh
   bin/cql-sh.sh: bin/cql-sh.sh

--- a/jobs/cassandra_injector/templates/bin/cql-sh.sh
+++ b/jobs/cassandra_injector/templates/bin/cql-sh.sh
@@ -13,7 +13,18 @@ export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF
 
 ## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 
-pushd /var/vcap/packages/cassandra/bin
-exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/cqlsh "$@"
-popd
-exit 0
+export CLIENT_SSL=<%=properties.cassandra_injector.client_encryption_options.enabled%>
+
+if [[ ${CLIENT_SSL} == "true" ]]
+then
+ pushd /var/vcap/packages/cassandra/bin
+ exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_injector/root/.cassandra/cqlshrc" "$@" --ssl
+ popd
+ exit 0
+else
+ pushd /var/vcap/packages/cassandra/bin
+ exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/cqlsh "$@"
+ popd
+ exit 0
+fi
+

--- a/jobs/cassandra_injector/templates/bin/creer_pem_cli_serv.sh
+++ b/jobs/cassandra_injector/templates/bin/creer_pem_cli_serv.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
+export CASSANDRA_SSL=/var/vcap/jobs/cassandra_injector/ssl
+cd ${CASSANDRA_SSL}
+
+export SSL_YN=<%=properties.cassandra_injector.cassandra_ssl_YN%>
+
+if ${SSL_YN} == "Y" 
+then
+ /var/vcap/jobs/cassandra_injector/bin/./generate_ssl_cert.sh
+fi
+
+popd >/dev/null
+exit 0

--- a/jobs/cassandra_injector/templates/bin/creer_pem_cli_serv.sh
+++ b/jobs/cassandra_injector/templates/bin/creer_pem_cli_serv.sh
@@ -4,14 +4,14 @@ set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
 
 pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
-export CASSANDRA_SSL=/var/vcap/jobs/cassandra_injector/ssl
+export CASSANDRA_SSL=/var/vcap/jobs/cassandra_injector/config/certs
 cd ${CASSANDRA_SSL}
 
 export SSL_YN=<%=properties.cassandra_injector.cassandra_ssl_YN%>
 
 if ${SSL_YN} == "Y" 
 then
- /var/vcap/jobs/cassandra_injector/bin/./generate_ssl_cert.sh
+ /var/vcap/jobs/cassandra_injector/config/certs/./ssl_env.ctl
 fi
 
 popd >/dev/null

--- a/jobs/cassandra_injector/templates/bin/generate_ssl_cert.sh
+++ b/jobs/cassandra_injector/templates/bin/generate_ssl_cert.sh
@@ -5,7 +5,7 @@ set -u # report the usage of uninitialized variables.
 
 #source `dirname $(readlink --canonicalize-existing $0)`/setenv
 
-#pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
+pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
 export CASSANDRA_SSL=/var/vcap/jobs/cassandra_injector/ssl
 cd ${CASSANDRA_SSL}
 
@@ -35,5 +35,5 @@ then
 	rm *.req *.srl *.crt *.key .rnd
 fi
 
-# popd >/dev/null
+popd >/dev/null
 exit 0

--- a/jobs/cassandra_injector/templates/bin/generate_ssl_cert.sh
+++ b/jobs/cassandra_injector/templates/bin/generate_ssl_cert.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+#source `dirname $(readlink --canonicalize-existing $0)`/setenv
+
+#pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
+export CASSANDRA_SSL=/var/vcap/jobs/cassandra_injector/ssl
+cd ${CASSANDRA_SSL}
+
+#[ -f server.pem ] && rm -f server.pem 
+#[ -f client.pem ] && rm -f client.pem
+
+touch .rnd
+export RANDFILE="${CASSANDRA_SSL}"/.rnd
+
+# generate only if client and server keys doesnt already exists
+if [ ! -f server.pem -o ! -f client.pem ]
+then
+	node_current_ip=`hostname -I`
+	perl -e 'my $n1=int(rand(10));my $n2=int(rand(10));print "$n1$n2\n"' > cassandradb.srl # two random digits number
+	openssl genrsa -out server.key 2048
+	openssl req -key server.key -new -out server.req -subj  "/C=FR/ST=IDF/O=Cloud Foundry/CN=${node_current_ip}/emailAddress=user@domain.com"
+	openssl x509 -req -in server.req -CA cassandradb.ca -CAkey cassandradb.pem -CAserial cassandradb.srl -out server.crt -days 3650
+	cat server.key server.crt > server.pem
+
+	openssl genrsa -out client.key 2048
+	openssl req -key client.key -new -out client.req -subj "/C=FR/ST=IDF/O=Cloud Foundry/CN=${node_current_ip}/emailAddress=user@domain.com"
+	openssl x509 -req -in client.req -CA cassandradb.ca -CAkey cassandra.pem -CAserial cassandradb.srl -out client.crt -days 3650
+	cat client.key client.crt > client.pem
+	#openssl verify -CAfile cassandradb.ca client.pem
+
+	# removing unneeded files
+	rm *.req *.srl *.crt *.key .rnd
+fi
+
+popd >/dev/null
+exit 0

--- a/jobs/cassandra_injector/templates/bin/generate_ssl_cert.sh
+++ b/jobs/cassandra_injector/templates/bin/generate_ssl_cert.sh
@@ -35,5 +35,5 @@ then
 	rm *.req *.srl *.crt *.key .rnd
 fi
 
-popd >/dev/null
+# popd >/dev/null
 exit 0

--- a/jobs/cassandra_injector/templates/bin/sec-sysauth.sh
+++ b/jobs/cassandra_injector/templates/bin/sec-sysauth.sh
@@ -6,21 +6,34 @@ set -u # report the usage of uninitialized variables.
 export LANG=en_US.UTF-8
 
 export CASSANDRA_BIN=/var/vcap/packages/cassandra/bin
-export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
+export CASSANDRA_CONF=/var/vcap/jobs/cassandra_injector/conf
 
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF
 
 export CASS_PWD="<%=properties.cassandra_injector.cass_pwd%>"
-## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_injector/conf
 
-/var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra 2>&1>/dev/null
-if [[ "$?" == 1 ]]; then
-/var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
-fi
-/var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
-/var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
+export CLIENT_SSL=<%properties.cassandra_injector.client_encryption_options.enabled%>
+
+if ${CLIENT_SSL} == "true"
+then
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_injector/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra --ssl 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_injector/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD --ssl 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_injector/root/.cassandra/cqlshrc"  -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD --ssl  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_injector/bin/./node-tool.sh repair system_auth
 #exit 0
+else
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_injector/bin/./node-tool.sh repair system_auth
+fi
 
-/var/vcap/jobs/cassandra_server/bin/./creer_pem_cli_serv.sh
+/var/vcap/jobs/cassandra_injector/bin/./creer_pem_cli_serv.sh
 exit 0
+

--- a/jobs/cassandra_injector/templates/bin/sec-sysauth.sh
+++ b/jobs/cassandra_injector/templates/bin/sec-sysauth.sh
@@ -6,24 +6,24 @@ set -u # report the usage of uninitialized variables.
 export LANG=en_US.UTF-8
 
 export CASSANDRA_BIN=/var/vcap/packages/cassandra/bin
-export CASSANDRA_CONF=/var/vcap/jobs/cassandra_injector/conf
+export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF
 
 export CASS_PWD="<%=properties.cassandra_injector.cass_pwd%>"
-## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_injector/conf
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 
-export CLIENT_SSL=<%properties.cassandra_injector.client_encryption_options.enabled%>
+export CLIENT_SSL=<%=properties.cassandra_injector.client_encryption_options.enabled%>
 
 if ${CLIENT_SSL} == "true"
 then
- /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_injector/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra --ssl 2>&1>/dev/null
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra --ssl 2>&1>/dev/null
  if [[ "$?" == 1 ]]; then
-  /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_injector/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD --ssl 2>&1>/dev/null
+  /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD --ssl 2>&1>/dev/null
  fi
- /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_injector/root/.cassandra/cqlshrc"  -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD --ssl  2>&1>/dev/null
- /var/vcap/jobs/cassandra_injector/bin/./node-tool.sh repair system_auth
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD --ssl  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
 #exit 0
 else
  /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra 2>&1>/dev/null
@@ -31,9 +31,27 @@ else
   /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
  fi
  /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
- /var/vcap/jobs/cassandra_injector/bin/./node-tool.sh repair system_auth
+ /var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
 fi
 
-/var/vcap/jobs/cassandra_injector/bin/./creer_pem_cli_serv.sh
+if ${CLIENT_SSL} == "true"
+then
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra --ssl 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD --ssl 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD --ssl  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
+#exit 0
+else
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
+fi
+
+/var/vcap/jobs/cassandra_server/bin/./creer_pem_cli_serv.sh
 exit 0
 

--- a/jobs/cassandra_injector/templates/bin/sec-sysauth.sh
+++ b/jobs/cassandra_injector/templates/bin/sec-sysauth.sh
@@ -19,7 +19,7 @@ if [[ "$?" == 1 ]]; then
 /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
 fi
 /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
-/var/vcap/jobs/cassandra_seed/bin/./node-tool.sh repair system_auth
+/var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
 #exit 0
 
 /var/vcap/jobs/cassandra_server/bin/./creer_pem_cli_serv.sh

--- a/jobs/cassandra_injector/templates/bin/sec-sysauth.sh
+++ b/jobs/cassandra_injector/templates/bin/sec-sysauth.sh
@@ -20,4 +20,7 @@ if [[ "$?" == 1 ]]; then
 fi
 /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
 /var/vcap/jobs/cassandra_seed/bin/./node-tool.sh repair system_auth
+#exit 0
+
+/var/vcap/jobs/cassandra_server/bin/./creer_pem_cli_serv.sh
 exit 0

--- a/jobs/cassandra_injector/templates/bin/sstable-loader.sh
+++ b/jobs/cassandra_injector/templates/bin/sstable-loader.sh
@@ -6,13 +6,13 @@ set -u # report the usage of uninitialized variables.
 export LANG=en_US.UTF-8
 
 export CASSANDRA_BIN=/var/vcap/packages/cassandra/bin
-export CASSANDRA_CONF=/var/vcap/jobs/cassandra_seed/conf
+export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 export CASSANDRA_TOOL=/var/vcap/packages/cassandra/tools/bin
 
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF:$CASSANDRA_TOOL
 export CASS_PWD="<%=properties.cassandra_injector.cass_pwd%>"
-## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_seed/conf
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 
 pushd /var/vcap/packages/cassandra/tools/bin
 if [ $# -eq 0 ];

--- a/jobs/cassandra_injector/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra_injector/templates/config/cassandra.yaml.erb
@@ -69,18 +69,18 @@ request_scheduler: <%=properties.cassandra_injector.request_scheduler%>
 internode_compression: <%=properties.cassandra_injector.internode_compression%>
 inter_dc_tcp_nodelay: <%=properties.cassandra_injector.inter_dc_tcp_nodelay%>
 server_encryption_options:
- internode_encryption: <%=properties.cassandra_injector.server_encryption_options.internode_encryption%>
- keystore: /var/vcap/jobs/cassandra_injector/config/certs/<%=spec.ip%>_cassandra.keystore
- keystore_password: <%=properties.cassandra_injector.cass_KSP%>
- truststore: /var/vcap/jobs/cassandra_injector/config/certs/<%=spec.ip%>_cassandra.truststore
- truststore_password: <%=properties.cassandra_injector.cass_KSP%>
+ internode_encryption: <%=properties.cassandra_server.server_encryption_options.internode_encryption%>
+ keystore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
+ keystore_password: <%=properties.cassandra_server.cass_KSP%>
+ truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.truststore
+ truststore_password: <%=properties.cassandra_server.cass_KSP%>
  protocol: TLS
 client_encryption_options:
- enabled: <%=properties.cassandra_injector.client_encryption_options.enabled%>
+ enabled: <%=properties.cassandra_server.client_encryption_options.enabled%>
 ##   optional: true
- keystore: /var/vcap/jobs/cassandra_injector/config/certs/<%=spec.ip%>_cassandra.keystore
- keystore_password: <%=properties.cassandra_injector.cass_KSP%>
- truststore: /var/vcap/jobs/cassandra_injector/config/certs/<%=spec.ip%>_cassandra.keystore
- truststore_password: <%=properties.cassandra_injector.cass_KSP%>
- require_client_auth: <%=properties.cassandra_injector.client_encryption_options.require_client_auth%>
+ keystore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
+ keystore_password: <%=properties.cassandra_server.cass_KSP%>
+ truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.truststore
+ truststore_password: <%=properties.cassandra_server.cass_KSP%>
+ require_client_auth: <%=properties.cassandra_server.client_encryption_options.require_client_auth%>
  protocol: TLS

--- a/jobs/cassandra_injector/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra_injector/templates/config/cassandra.yaml.erb
@@ -68,3 +68,19 @@ dynamic_snitch_badness_threshold: <%=properties.cassandra_injector.dynamic_snitc
 request_scheduler: <%=properties.cassandra_injector.request_scheduler%>
 internode_compression: <%=properties.cassandra_injector.internode_compression%>
 inter_dc_tcp_nodelay: <%=properties.cassandra_injector.inter_dc_tcp_nodelay%>
+server_encryption_options:
+ internode_encryption: none
+ keystore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
+ keystore_password: <%=properties.cassandra_server.cass_KSP%>
+ truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.truststore
+ truststore_password: <%=properties.cassandra_server.cass_KSP%>
+ protocol: TLS
+client_encryption_options:
+ enabled: false
+ optional: true
+ keystore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
+ keystore_password: <%=properties.cassandra_server.cass_KSP%>
+ truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
+ truststore_password: <%=properties.cassandra_server.cass_KSP%>
+ require_client_auth: true
+ protocol: TLS

--- a/jobs/cassandra_injector/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra_injector/templates/config/cassandra.yaml.erb
@@ -69,18 +69,18 @@ request_scheduler: <%=properties.cassandra_injector.request_scheduler%>
 internode_compression: <%=properties.cassandra_injector.internode_compression%>
 inter_dc_tcp_nodelay: <%=properties.cassandra_injector.inter_dc_tcp_nodelay%>
 server_encryption_options:
- internode_encryption: none
- keystore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
- keystore_password: <%=properties.cassandra_server.cass_KSP%>
- truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.truststore
- truststore_password: <%=properties.cassandra_server.cass_KSP%>
+ internode_encryption: <%=properties.cassandra_injector.server_encryption_options.internode_encryption%>
+ keystore: /var/vcap/jobs/cassandra_injector/config/certs/<%=spec.ip%>_cassandra.keystore
+ keystore_password: <%=properties.cassandra_injector.cass_KSP%>
+ truststore: /var/vcap/jobs/cassandra_injector/config/certs/<%=spec.ip%>_cassandra.truststore
+ truststore_password: <%=properties.cassandra_injector.cass_KSP%>
  protocol: TLS
 client_encryption_options:
- enabled: false
- optional: true
- keystore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
- keystore_password: <%=properties.cassandra_server.cass_KSP%>
- truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
- truststore_password: <%=properties.cassandra_server.cass_KSP%>
- require_client_auth: true
+ enabled: <%=properties.cassandra_injector.client_encryption_options.enabled%>
+##   optional: true
+ keystore: /var/vcap/jobs/cassandra_injector/config/certs/<%=spec.ip%>_cassandra.keystore
+ keystore_password: <%=properties.cassandra_injector.cass_KSP%>
+ truststore: /var/vcap/jobs/cassandra_injector/config/certs/<%=spec.ip%>_cassandra.keystore
+ truststore_password: <%=properties.cassandra_injector.cass_KSP%>
+ require_client_auth: <%=properties.cassandra_injector.client_encryption_options.require_client_auth%>
  protocol: TLS

--- a/jobs/cassandra_injector/templates/config/cqlshrc.erb
+++ b/jobs/cassandra_injector/templates/config/cqlshrc.erb
@@ -1,20 +1,20 @@
 [authentication]
 username = cassandra
-password = <%=properties.cassandra_injector.cass_KSP%>
+password = <%=properties.cassandra_injector.cass_pwd%>
 ;;keyspace = 
 
 
 [connection]
-hostname = <%spec.ip%>
+hostname = <%=spec.ip%>
 port = 9042
-ssl = <%= properties.cassandra_injector.cassandra_ssl_YN%>
+ssl = <%=properties.cassandra_injector.cassandra_ssl_YN%>
 request_timeout = 1800
 
 [ssl]
-certfile = /var/vcap/jobs/cassandra_injector/config/certs/<%spec.ip%>_<%=properties.cassandra_injector.cluster_name%>_CLIENT.cer.pem
+certfile = /var/vcap/jobs/cassandra_injector/config/certs/<%=spec.ip%>_<%=properties.cassandra_injector.cluster_name%>_CLIENT.cer.pem
 validate = <%=properties.cassandra_injector.validate_ssl_TF%>
-userkey = /var/vcap/jobs/cassandra_injector/config/certs/<%spec.ip%>_<%=properties.cassandra_injector.cluster_name%>_CLIENT.key.pem
-usercert = /var/vcap/jobs/cassandra_injector/config/certs/<%spec.ip%>_<%=properties.cassandra_injector.cluster_name%>_CLIENT.cer.pem
+userkey = /var/vcap/jobs/cassandra_injector/config/certs/<%=spec.ip%>_<%=properties.cassandra_injector.cluster_name%>_CLIENT.key.pem
+usercert = /var/vcap/jobs/cassandra_injector/config/certs/<%=spec.ip%>_<%=properties.cassandra_injector.cluster_name%>_CLIENT.cer.pem
 
 ;; Optional section, overrides default certfile in [ssl] section, if present
 ; [certfiles]

--- a/jobs/cassandra_injector/templates/config/cqlshrc.erb
+++ b/jobs/cassandra_injector/templates/config/cqlshrc.erb
@@ -1,0 +1,23 @@
+[authentication]
+username = cassandra
+password = <%=properties.cassandra_injector.cass_KSP%>
+;;keyspace = 
+
+
+[connection]
+hostname = <%spec.ip%>
+port = 9042
+ssl = <%= properties.cassandra_injector.cassandra_ssl_YN%>
+request_timeout = 1800
+
+[ssl]
+certfile = /var/vcap/jobs/cassandra_injector/config/certs/<%spec.ip%>_<%=properties.cassandra_injector.cluster_name%>_CLIENT.cer.pem
+validate = <%=properties.cassandra_injector.validate_ssl_TF%>
+userkey = /var/vcap/jobs/cassandra_injector/config/certs/<%spec.ip%>_<%=properties.cassandra_injector.cluster_name%>_CLIENT.key.pem
+usercert = /var/vcap/jobs/cassandra_injector/config/certs/<%spec.ip%>_<%=properties.cassandra_injector.cluster_name%>_CLIENT.cer.pem
+
+;; Optional section, overrides default certfile in [ssl] section, if present
+; [certfiles]
+; 192.168.1.3 = ~/keys/cassandra01.cert
+; 192.168.1.4 = ~/keys/cassandra02.cert
+

--- a/jobs/cassandra_injector/templates/helpers/ctl_setup.sh
+++ b/jobs/cassandra_injector/templates/helpers/ctl_setup.sh
@@ -92,3 +92,19 @@ echo ' verif creation rep graph : ' `ls -ltr $JOB_DIR/tools/bin/graph`
 chmod +x  $JOB_DIR/tools/bin/cassandra-stress.sh
 echo ' verif cassandra-stress : ' `ls -ltr $JOB_DIR/tools/bin/cassandra-stress.sh`
 mkdir -p $JOB_DIR/ssl
+
+chmod +x $JOB_DIR/config/certs/ssl_env.ctl
+chmod +x $JOB_DIR/config/certs/gen_keystore_client.sh
+
+if [[ -d ${JOB_DIR}/config/certs/newcerts ]]
+then
+ rm -rf $JOB_DIR/config/certs/newcerts/
+ mkdir -p $JOB_DIR/config/certs/newcerts
+else
+ mkdir -p $JOB_DIR/config/certs/newcerts
+fi
+
+chown vcap:vcap ${JOB_DIR}/config/certs/newcerts
+chown vcap:vcap ${JOB_DIR}/config/certs/
+
+mount -o remount ,exec,suid,nodev /tmp

--- a/jobs/cassandra_injector/templates/helpers/ctl_setup.sh
+++ b/jobs/cassandra_injector/templates/helpers/ctl_setup.sh
@@ -91,4 +91,4 @@ chmod 777 $JOB_DIR/tools/bin/graph
 echo ' verif creation rep graph : ' `ls -ltr $JOB_DIR/tools/bin/graph`
 chmod +x  $JOB_DIR/tools/bin/cassandra-stress.sh
 echo ' verif cassandra-stress : ' `ls -ltr $JOB_DIR/tools/bin/cassandra-stress.sh`
-
+mkdir -p $JOB_DIR/ssl

--- a/jobs/cassandra_injector/templates/ssl/cassandradb.ca.erb
+++ b/jobs/cassandra_injector/templates/ssl/cassandradb.ca.erb
@@ -1,0 +1,1 @@
+<%= p("cassandra_injector.cassDbCertificate.ca") -%>

--- a/jobs/cassandra_injector/templates/ssl/cassandradb.pem.erb
+++ b/jobs/cassandra_injector/templates/ssl/cassandradb.pem.erb
@@ -1,0 +1,2 @@
+<%= p("cassandra_injector.cassDbCertificate.certificate") -%>
+<%= p("cassandra_injector.cassDbCertificate.private_key") -%>

--- a/jobs/cassandra_injector/templates/ssl2/cert
+++ b/jobs/cassandra_injector/templates/ssl2/cert
@@ -1,0 +1,1 @@
+<%= p("cassandra_injector.cert.certificate") %>

--- a/jobs/cassandra_injector/templates/ssl2/cert_ca
+++ b/jobs/cassandra_injector/templates/ssl2/cert_ca
@@ -1,0 +1,1 @@
+<%= p("cassandra_injector.cert.ca") %>

--- a/jobs/cassandra_injector/templates/ssl2/cert_private_key
+++ b/jobs/cassandra_injector/templates/ssl2/cert_private_key
@@ -1,0 +1,1 @@
+<%= p("cassandra_injector.cert.private_key") %>

--- a/jobs/cassandra_injector/templates/ssl2/gen_ca_cert.conf
+++ b/jobs/cassandra_injector/templates/ssl2/gen_ca_cert.conf
@@ -1,0 +1,35 @@
+[ ca ]
+default_ca =internalCA
+[ internalCA ]
+dir =/var/vcap/packages/cassandra_injector/config/certs/
+certificate = $dir/ca.cert
+database = $dir/index.txt
+serial = $dir/serial
+new_certs_dir = $dir/newcerts
+private_key = $dir/node.key
+default_days = 365
+default_md = md5
+policy = CAuser_policy
+
+[ CAuser_policy ]
+stateOrProvinceName = optional
+countryName = supplied
+organizationName = supplied
+organizationalUnitName =optional
+commonName = supplied
+
+[ req ]
+distinguished_name = req_cassandra
+prompt = no
+default_bits = 2048
+default_keyfile = $dir/node.key
+
+[ req_cassandra ]
+C = FR
+ST = FR
+L = LYON
+O = Orange
+OU = TestCluster
+CN = `hostname -I`
+emailAddress = omer.missoum@orange.com
+

--- a/jobs/cassandra_injector/templates/ssl2/gen_keystore_client.sh
+++ b/jobs/cassandra_injector/templates/ssl2/gen_keystore_client.sh
@@ -2,7 +2,7 @@
 #set -x
 set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
-cd /var/vcap/jobs/cassandra_injector/config/certs/
+cd /var/vcap/jobs/cassandra_server/config/certs/
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:$JAVA_HOME/bin:.
 

--- a/jobs/cassandra_injector/templates/ssl2/gen_keystore_client.sh
+++ b/jobs/cassandra_injector/templates/ssl2/gen_keystore_client.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+cd /var/vcap/jobs/cassandra_injector/config/certs/
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin:.
+
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+export STOREPASS="<%=properties.cassandra_injector.cass_KSP%>"
+export KEYPASS=$STOREPASS
+keytool -genkeypair -keyalg RSA -alias ${HOST_NAME} -keystore ${HOST_NAME}.jks -storepass $STOREPASS -keypass $KEYPASS -validity 3650 -keysize 2048 -dname "CN=${HOST_NAME}, OU=TestCluster, O=Orange, L=Lyon, S=FR, C=FR"
+
+keytool -keystore ${HOST_NAME}.jks -alias ${HOST_NAME} -certreq -file ${HOST_NAME}.csr -keypass $KEYPASS -storepass $STOREPASS
+exit 0

--- a/jobs/cassandra_injector/templates/ssl2/ssl_env.ctl.erb
+++ b/jobs/cassandra_injector/templates/ssl2/ssl_env.ctl.erb
@@ -1,0 +1,21 @@
+#!/bin/bash
+#set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin
+export IN_OU_CERT_REQ=/var/vcap/jobs/cassandra_injector/config/certs/
+export CA_CERT_PEM=/var/vcap/jobs/cassandra_injector/config/certs/cert
+
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_injector/conf
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+
+pushd /var/vcap/jobs/cassandra_injector/config/certs/
+exec chpst -u vcap:vcap /var/vcap/jobs/cassandra_injector/config/certs/./gen_keystore_client.sh 
+popd
+
+openssl ca -config ${IN_OU_CERT_REQ}/gen_ca_cert.conf -in ${IN_OU_CERT_REQ}/${HOST_NAME}.csr
+
+exit 0

--- a/jobs/cassandra_injector/templates/ssl2/ssl_env.ctl.erb
+++ b/jobs/cassandra_injector/templates/ssl2/ssl_env.ctl.erb
@@ -5,15 +5,15 @@ set -u # report the usage of uninitialized variables.
 
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:$JAVA_HOME/bin
-export IN_OU_CERT_REQ=/var/vcap/jobs/cassandra_injector/config/certs/
-export CA_CERT_PEM=/var/vcap/jobs/cassandra_injector/config/certs/cert
+export IN_OU_CERT_REQ=/var/vcap/jobs/cassandra_server/config/certs/
+export CA_CERT_PEM=/var/vcap/jobs/cassandra_server/config/certs/cert
 
-## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_injector/conf
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 export HOST_NAME1=`hostname -I`
 export HOST_NAME=${HOST_NAME1//[[:space:]]}
 
-pushd /var/vcap/jobs/cassandra_injector/config/certs/
-exec chpst -u vcap:vcap /var/vcap/jobs/cassandra_injector/config/certs/./gen_keystore_client.sh 
+pushd /var/vcap/jobs/cassandra_server/config/certs/
+exec chpst -u vcap:vcap /var/vcap/jobs/cassandra_server/config/certs/./gen_keystore_client.sh 
 popd
 
 openssl ca -config ${IN_OU_CERT_REQ}/gen_ca_cert.conf -in ${IN_OU_CERT_REQ}/${HOST_NAME}.csr

--- a/jobs/cassandra_injector/templates/ssl3/gen_keystore_client.sh
+++ b/jobs/cassandra_injector/templates/ssl3/gen_keystore_client.sh
@@ -2,20 +2,21 @@
 #set -x
 set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
-export KEY_STORE_PATH=/var/vcap/jobs/cassandra_server/config/certs/
+export KEY_STORE_PATH=/var/vcap/jobs/cassandra_injector/config/certs/
 cd ${KEY_STORE_PATH}
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:$JAVA_HOME/bin:.
+
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
 
 export KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.keystore"
 export PKS_KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.pks12.keystore"
 export TRUST_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.truststore"
 export CLUSTER_NAME="<%=properties.cassandra_injector.cluster_name%>"
-export CLUSTER_PUBLIC_CERT="$KEY_STORE_PATH/CLUSTER_${CLUSTER_NAME}_PUBLIC.cer"
-export CLIENT_PUBLIC_CERT="$KEY_STORE_PATH/CLIENT_${CLUSTER_NAME}_PUBLIC.cer"
+export CLUSTER_PUBLIC_CERT="$KEY_STORE_PATH/${HOST_NAME}_CLUSTER_${CLUSTER_NAME}_PUBLIC.cer"
+export CLIENT_PUBLIC_CERT="$KEY_STORE_PATH/${HOST_NAME}_CLIENT_${CLUSTER_NAME}_PUBLIC.cer"
 
-export HOST_NAME1=`hostname -I`
-export HOST_NAME=${HOST_NAME1//[[:space:]]}
 export STOREPASS="<%=properties.cassandra_injector.cass_KSP%>"
 export KEYPASS=$STOREPASS
 export PASSWORD=$KEYPASS
@@ -23,40 +24,38 @@ export PASSWORD=$KEYPASS
 
 ### Cluster key setup.
 # Create the cluster key for cluster communication.
-keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLUSTER" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+keytool -genkey -keyalg RSA -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
 -dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
 -validity 36500
 
 # Create the public key for the cluster which is used to identify nodes.
-keytool -export -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$KEY_STORE" \
+keytool -export -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$KEY_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
 
 # Import the identity of the cluster public cluster key into the trust store so that nodes can identify each other.
-keytool -import -v -trustcacerts -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+keytool -import -v -trustcacerts -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$TRUST_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
 
 
 ### Client key setup.
 # Create the client key for CQL.
-keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLIENT" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+keytool -genkey -keyalg RSA -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
 -dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
 -validity 36500
 
 # Create the public key for the client to identify itself.
-keytool -export -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$KEY_STORE" \
+keytool -export -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$KEY_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
 
 # Import the identity of the client pub  key into the trust store so nodes can identify this client.
-keytool -importcert -v -trustcacerts -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+keytool -importcert -v -trustcacerts -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$TRUST_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
-
-
 
 keytool -importkeystore -srckeystore "$KEY_STORE" -destkeystore "$PKS_KEY_STORE" -deststoretype PKCS12 \
 -srcstorepass "$PASSWORD" -deststorepass "$PASSWORD"
 
-openssl pkcs12 -in "$PKS_KEY_STORE" -nokeys -out "${CLUSTER_NAME}_CLIENT.cer.pem" -passin pass:"$PASSWORD"
-openssl pkcs12 -in "$PKS_KEY_STORE" -nodes -nocerts -out "${CLUSTER_NAME}_CLIENT.key.pem" -passin pass:"$PASSWORD"
+openssl pkcs12 -in "$PKS_KEY_STORE" -nokeys -out "${HOST_NAME}_${CLUSTER_NAME}_CLIENT.cer.pem" -passin pass:"$PASSWORD"
+openssl pkcs12 -in "$PKS_KEY_STORE" -nodes -nocerts -out "${HOST_NAME}_${CLUSTER_NAME}_CLIENT.key.pem" -passin pass:"$PASSWORD"
 
 
 exit 0

--- a/jobs/cassandra_injector/templates/ssl3/gen_keystore_client.sh
+++ b/jobs/cassandra_injector/templates/ssl3/gen_keystore_client.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+export KEY_STORE_PATH=/var/vcap/jobs/cassandra_server/config/certs/
+cd ${KEY_STORE_PATH}
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin:.
+
+export KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.keystore"
+export PKS_KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.pks12.keystore"
+export TRUST_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.truststore"
+export CLUSTER_NAME="<%=properties.cassandra_injector.cluster_name%>"
+export CLUSTER_PUBLIC_CERT="$KEY_STORE_PATH/CLUSTER_${CLUSTER_NAME}_PUBLIC.cer"
+export CLIENT_PUBLIC_CERT="$KEY_STORE_PATH/CLIENT_${CLUSTER_NAME}_PUBLIC.cer"
+
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+export STOREPASS="<%=properties.cassandra_injector.cass_KSP%>"
+export KEYPASS=$STOREPASS
+export PASSWORD=$KEYPASS
+
+
+### Cluster key setup.
+# Create the cluster key for cluster communication.
+keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLUSTER" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+-dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
+-validity 36500
+
+# Create the public key for the cluster which is used to identify nodes.
+keytool -export -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$KEY_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+# Import the identity of the cluster public cluster key into the trust store so that nodes can identify each other.
+keytool -import -v -trustcacerts -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+
+### Client key setup.
+# Create the client key for CQL.
+keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLIENT" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+-dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
+-validity 36500
+
+# Create the public key for the client to identify itself.
+keytool -export -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$KEY_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+# Import the identity of the client pub  key into the trust store so nodes can identify this client.
+keytool -importcert -v -trustcacerts -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+
+
+keytool -importkeystore -srckeystore "$KEY_STORE" -destkeystore "$PKS_KEY_STORE" -deststoretype PKCS12 \
+-srcstorepass "$PASSWORD" -deststorepass "$PASSWORD"
+
+openssl pkcs12 -in "$PKS_KEY_STORE" -nokeys -out "${CLUSTER_NAME}_CLIENT.cer.pem" -passin pass:"$PASSWORD"
+openssl pkcs12 -in "$PKS_KEY_STORE" -nodes -nocerts -out "${CLUSTER_NAME}_CLIENT.key.pem" -passin pass:"$PASSWORD"
+
+
+exit 0
+

--- a/jobs/cassandra_injector/templates/ssl3/ssl_env.ctl.erb
+++ b/jobs/cassandra_injector/templates/ssl3/ssl_env.ctl.erb
@@ -1,0 +1,22 @@
+#!/bin/bash
+#set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin
+export IN_OU_CERT_REQ=/var/vcap/jobs/cassandra_server/config/certs/
+export CA_CERT_PEM=/var/vcap/jobs/cassandra_server/config/certs/cert
+
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+
+pushd /var/vcap/jobs/cassandra_server/config/certs/
+exec chpst -u vcap:vcap /var/vcap/jobs/cassandra_server/config/certs/./gen_keystore_client.sh
+popd
+
+#openssl ca -config ${IN_OU_CERT_REQ}/gen_ca_cert.conf -in ${IN_OU_CERT_REQ}/${HOST_NAME}.csr
+
+exit 0
+

--- a/jobs/cassandra_injector/templates/ssl3/ssl_env.ctl.erb
+++ b/jobs/cassandra_injector/templates/ssl3/ssl_env.ctl.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-set -e # exit immediately if a simple command exits with a non-zero status.
+#set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
 
 export JAVA_HOME=/var/vcap/packages/openjdk

--- a/jobs/cassandra_seed/spec
+++ b/jobs/cassandra_seed/spec
@@ -35,12 +35,14 @@ templates:
 #  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
 #  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
 #  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
-  ssl2/cert: config/certs/node.crt
-  ssl2/cert_ca: config/certs/ca.crt
-  ssl2/cert_private_key: config/certs/node.key
-  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
-  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
-  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
+#  ssl2/cert: config/certs/node.crt
+#  ssl2/cert_ca: config/certs/ca.crt
+#  ssl2/cert_private_key: config/certs/node.key
+#  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
+#  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
+#  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
+  ssl3/ssl_env.ctl.erb: config/certs/ssl_env.ctl
+  ssl3/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
   bin/creer_pem_cli_serv.sh: bin/creer_pem_cli_serv.sh

--- a/jobs/cassandra_seed/spec
+++ b/jobs/cassandra_seed/spec
@@ -34,9 +34,9 @@ templates:
 #  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
 #  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
 #  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
- ssl2/cert: config/certs/node.crt
- ssl2/cert_ca: config/certs/ca.crt
- ssl2/cert_private_key: config/certs/node.key
+  ssl2/cert: config/certs/node.crt
+  ssl2/cert_ca: config/certs/ca.crt
+  ssl2/cert_private_key: config/certs/node.key
 #  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
 #  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
 #  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf

--- a/jobs/cassandra_seed/spec
+++ b/jobs/cassandra_seed/spec
@@ -32,9 +32,15 @@ templates:
   config/logback-tools.xml.erb: conf/logback-tools.xml
   config/commitlog_archiving.properties.erb: conf/commitlog_archiving.properties
   config/cqlshrc.sample.erb: conf/cqlshrc.sample
-  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
-  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
-  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
+#  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
+#  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
+#  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
+  ssl2/cert: config/certs/node.crt
+  ssl2/cert_ca: config/certs/ca.crt
+  ssl2/cert_private_key: config/certs/node.key
+  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
+  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
+  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
   bin/creer_pem_cli_serv.sh: bin/creer_pem_cli_serv.sh
@@ -246,3 +252,9 @@ properties:
   cassandra_seed.cassDbCertificate:
     default: "NOT INITIALIZED"
     description: use tls/ssl for authent and transactions 
+  cassandra_seed.cert:
+    type: certificate
+    description: cluster certificate
+  cassandra_seed.cass_KSP:
+    default: 
+    description: cassandra ssl keystore passwd

--- a/jobs/cassandra_seed/spec
+++ b/jobs/cassandra_seed/spec
@@ -31,7 +31,6 @@ templates:
   config/logback.xml.erb: conf/logback.xml
   config/logback-tools.xml.erb: conf/logback-tools.xml
   config/commitlog_archiving.properties.erb: conf/commitlog_archiving.properties
-  config/cqlshrc.sample.erb: conf/cqlshrc.sample
 #  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
 #  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
 #  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
@@ -41,12 +40,14 @@ templates:
 #  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
 #  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
 #  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
+  config/cqlshrc.erb: root/.cassandra/cqlshrc
   ssl3/ssl_env.ctl.erb: config/certs/ssl_env.ctl
   ssl3/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
   bin/creer_pem_cli_serv.sh: bin/creer_pem_cli_serv.sh
   bin/sec-sysauth.sh: bin/post-start
+  
 
 properties:
   cassandra_seed.cluster_name:
@@ -260,3 +261,15 @@ properties:
   cassandra_seed.cass_KSP:
     default: 
     description: cassandra ssl keystore passwd
+  cassandra_seed.validate_ssl_TF:
+    default: false
+    description: cassandra ssl validate true or false
+  cassandra_seed.server_encryption_options.internode_encryption:
+    default: false
+    description: cassandra ssl entre noeuds true or false
+  cassandra_seed.client_encryption_options.enabled:
+    default: false
+    description: cassandra ssl entre client et server true or false
+  cassandra_seed.client_encryption_options.require_client_auth:
+    default: false
+    description: cassandra ssl entre client et server et authentifi 

--- a/jobs/cassandra_seed/spec
+++ b/jobs/cassandra_seed/spec
@@ -37,6 +37,7 @@ templates:
   ssl/cassandradb.pem.erb: ssl/cassandradb.pem
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
+  bin/creer_pem_cli_serv.sh: bin/creer_pem_cli_serv.sh
   bin/sec-sysauth.sh: bin/post-start
 
 properties:
@@ -239,8 +240,8 @@ properties:
     description:
   cassandra_seed.cass_pwd:
     default: cassandra
-  cassandra_seed.cassConf_ssl:
-    default: 1
+  cassandra_seed.cassandra_ssl_YN:
+    default: N
     description: use tls/ssl for authent and transactions 
   cassandra_seed.cassDbCertificate:
     default: "NOT INITIALIZED"

--- a/jobs/cassandra_seed/spec
+++ b/jobs/cassandra_seed/spec
@@ -32,6 +32,9 @@ templates:
   config/logback-tools.xml.erb: conf/logback-tools.xml
   config/commitlog_archiving.properties.erb: conf/commitlog_archiving.properties
   config/cqlshrc.sample.erb: conf/cqlshrc.sample
+  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
+  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
+  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
   bin/sec-sysauth.sh: bin/post-start
@@ -236,3 +239,9 @@ properties:
     description:
   cassandra_seed.cass_pwd:
     default: cassandra
+  cassandra_seed.cassConf_ssl:
+    default: 1
+    description: use tls/ssl for authent and transactions 
+  cassandra_seed.cassDbCertificate:
+    default: "NOT INITIALIZED"
+    description: use tls/ssl for authent and transactions 

--- a/jobs/cassandra_seed/spec
+++ b/jobs/cassandra_seed/spec
@@ -34,9 +34,9 @@ templates:
 #  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
 #  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
 #  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
-#  ssl2/cert: config/certs/node.crt
-#  ssl2/cert_ca: config/certs/ca.crt
-#  ssl2/cert_private_key: config/certs/node.key
+ ssl2/cert: config/certs/node.crt
+ ssl2/cert_ca: config/certs/ca.crt
+ ssl2/cert_private_key: config/certs/node.key
 #  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
 #  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
 #  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf

--- a/jobs/cassandra_seed/templates/bin/cassandra_seed.ctl
+++ b/jobs/cassandra_seed/templates/bin/cassandra_seed.ctl
@@ -33,7 +33,7 @@ case $1 in
 
     ;;
   *)
-    echo "Usage: cassandra_seed_ctl {start|stop}"
+    echo "Usage: cassandra_seed.ctl {start|stop}"
 
     ;;
 

--- a/jobs/cassandra_seed/templates/bin/cql-sh.sh
+++ b/jobs/cassandra_seed/templates/bin/cql-sh.sh
@@ -13,7 +13,17 @@ export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF
 
 ## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 
-pushd /var/vcap/packages/cassandra/bin
-exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/cqlsh "$@"
-popd
-exit 0
+export CLIENT_SSL=<%=properties.cassandra_seed.client_encryption_options.enabled%>
+
+if [[ ${CLIENT_SSL} == "true" ]]
+then 
+ pushd /var/vcap/packages/cassandra/bin
+ exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_seed/root/.cassandra/cqlshrc" "$@" --ssl
+ popd
+ exit 0
+else 
+ pushd /var/vcap/packages/cassandra/bin
+ exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/cqlsh "$@"
+ popd
+ exit 0
+fi

--- a/jobs/cassandra_seed/templates/bin/creer_pem_cli_serv.sh
+++ b/jobs/cassandra_seed/templates/bin/creer_pem_cli_serv.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
+export CASSANDRA_SSL=/var/vcap/jobs/cassandra_seed/ssl
+cd ${CASSANDRA_SSL}
+
+export SSL_YN=<%=properties.cassandra_seed.cassandra_ssl_YN%>
+
+if ${SSL_YN} == "Y" 
+then
+ /var/vcap/jobs/cassandra_seed/bin/./generate_ssl_cert.sh
+fi
+
+popd >/dev/null
+exit 0

--- a/jobs/cassandra_seed/templates/bin/creer_pem_cli_serv.sh
+++ b/jobs/cassandra_seed/templates/bin/creer_pem_cli_serv.sh
@@ -4,14 +4,15 @@ set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
 
 pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
-export CASSANDRA_SSL=/var/vcap/jobs/cassandra_seed/ssl
+export CASSANDRA_SSL=/var/vcap/jobs/cassandra_seed/config/certs
 cd ${CASSANDRA_SSL}
 
 export SSL_YN=<%=properties.cassandra_seed.cassandra_ssl_YN%>
 
 if ${SSL_YN} == "Y" 
 then
- /var/vcap/jobs/cassandra_seed/bin/./generate_ssl_cert.sh
+ /var/vcap/jobs/cassandra_seed/config/certs/./ssl_env.ctl
+
 fi
 
 popd >/dev/null

--- a/jobs/cassandra_seed/templates/bin/generate_ssl_cert.sh
+++ b/jobs/cassandra_seed/templates/bin/generate_ssl_cert.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+#source `dirname $(readlink --canonicalize-existing $0)`/setenv
+
+#pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
+export CASSANDRA_SSL=/var/vcap/jobs/cassandra_seed/ssl
+cd ${CASSANDRA_SSL}
+
+#[ -f server.pem ] && rm -f server.pem 
+#[ -f client.pem ] && rm -f client.pem
+
+touch .rnd
+export RANDFILE="${CASSANDRA_SSL}"/.rnd
+
+# generate only if client and server keys doesnt already exists
+if [ ! -f server.pem -o ! -f client.pem ]
+then
+	node_current_ip=`hostname -I`
+	perl -e 'my $n1=int(rand(10));my $n2=int(rand(10));print "$n1$n2\n"' > cassandradb.srl # two random digits number
+	openssl genrsa -out server.key 2048
+	openssl req -key server.key -new -out server.req -subj  "/C=FR/ST=IDF/O=Cloud Foundry/CN=${node_current_ip}/emailAddress=user@domain.com"
+	openssl x509 -req -in server.req -CA cassandradb.ca -CAkey cassandradb.pem -CAserial cassandradb.srl -out server.crt -days 3650
+	cat server.key server.crt > server.pem
+
+	openssl genrsa -out client.key 2048
+	openssl req -key client.key -new -out client.req -subj "/C=FR/ST=IDF/O=Cloud Foundry/CN=${node_current_ip}/emailAddress=user@domain.com"
+	openssl x509 -req -in client.req -CA cassandradb.ca -CAkey cassandra.pem -CAserial cassandradb.srl -out client.crt -days 3650
+	cat client.key client.crt > client.pem
+	#openssl verify -CAfile cassandradb.ca client.pem
+
+	# removing unneeded files
+	rm *.req *.srl *.crt *.key .rnd
+fi
+
+popd >/dev/null
+exit 0

--- a/jobs/cassandra_seed/templates/bin/generate_ssl_cert.sh
+++ b/jobs/cassandra_seed/templates/bin/generate_ssl_cert.sh
@@ -27,7 +27,7 @@ then
 
 	openssl genrsa -out client.key 2048
 	openssl req -key client.key -new -out client.req -subj "/C=FR/ST=IDF/O=Cloud Foundry/CN=${node_current_ip}/emailAddress=user@domain.com"
-	openssl x509 -req -in client.req -CA cassandradb.ca -CAkey cassandra.pem -CAserial cassandradb.srl -out client.crt -days 3650
+	openssl x509 -req -in client.req -CA cassandradb.ca -CAkey cassandradb.pem -CAserial cassandradb.srl -out client.crt -days 3650
 	cat client.key client.crt > client.pem
 	#openssl verify -CAfile cassandradb.ca client.pem
 
@@ -35,5 +35,5 @@ then
 	rm *.req *.srl *.crt *.key .rnd
 fi
 
-popd >/dev/null
+# popd >/dev/null
 exit 0

--- a/jobs/cassandra_seed/templates/bin/generate_ssl_cert.sh
+++ b/jobs/cassandra_seed/templates/bin/generate_ssl_cert.sh
@@ -5,7 +5,7 @@ set -u # report the usage of uninitialized variables.
 
 #source `dirname $(readlink --canonicalize-existing $0)`/setenv
 
-#pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
+pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
 export CASSANDRA_SSL=/var/vcap/jobs/cassandra_seed/ssl
 cd ${CASSANDRA_SSL}
 
@@ -35,5 +35,5 @@ then
 	rm *.req *.srl *.crt *.key .rnd
 fi
 
-# popd >/dev/null
+popd >/dev/null
 exit 0

--- a/jobs/cassandra_seed/templates/bin/sec-sysauth.sh
+++ b/jobs/cassandra_seed/templates/bin/sec-sysauth.sh
@@ -13,14 +13,25 @@ export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF
 
 export CASS_PWD="<%=properties.cassandra_seed.cass_pwd%>"
 ## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
+export CLIENT_SSL=<%properties.cassandra_seed.client_encryption_options.enabled%>
 
-/var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra 2>&1>/dev/null
-if [[ "$?" == 1 ]]; then
-/var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
-fi
-/var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
-/var/vcap/jobs/cassandra_seed/bin/./node-tool.sh repair system_auth
+if ${CLIENT_SSL} == "true"
+then
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_seed/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra --ssl 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_seed/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD --ssl 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_seed/root/.cassandra/cqlshrc"  -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD --ssl  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_seed/bin/./node-tool.sh repair system_auth
 #exit 0
+else
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_seed/bin/./node-tool.sh repair system_auth
+fi
 
 /var/vcap/jobs/cassandra_seed/bin/./creer_pem_cli_serv.sh
 exit 0

--- a/jobs/cassandra_seed/templates/bin/sec-sysauth.sh
+++ b/jobs/cassandra_seed/templates/bin/sec-sysauth.sh
@@ -20,4 +20,7 @@ if [[ "$?" == 1 ]]; then
 fi
 /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
 /var/vcap/jobs/cassandra_seed/bin/./node-tool.sh repair system_auth
+#exit 0
+
+/var/vcap/jobs/cassandra_seed/bin/./creer_pem_cli_serv.sh
 exit 0

--- a/jobs/cassandra_seed/templates/bin/sec-sysauth.sh
+++ b/jobs/cassandra_seed/templates/bin/sec-sysauth.sh
@@ -6,14 +6,32 @@ set -u # report the usage of uninitialized variables.
 export LANG=en_US.UTF-8
 
 export CASSANDRA_BIN=/var/vcap/packages/cassandra/bin
-export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
+export CASSANDRA_CONF=/var/vcap/jobs/cassandra_seed/conf
 
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF
 
 export CASS_PWD="<%=properties.cassandra_seed.cass_pwd%>"
-## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
-export CLIENT_SSL=<%properties.cassandra_seed.client_encryption_options.enabled%>
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_seed/conf
+export CLIENT_SSL=<%=properties.cassandra_seed.client_encryption_options.enabled%>
+
+if ${CLIENT_SSL} == "true"
+then
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_seed/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra --ssl 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_seed/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD --ssl 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_seed/root/.cassandra/cqlshrc"  -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD --ssl  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_seed/bin/./node-tool.sh repair system_auth
+#exit 0
+else
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_seed/bin/./node-tool.sh repair system_auth
+fi
 
 if ${CLIENT_SSL} == "true"
 then

--- a/jobs/cassandra_seed/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra_seed/templates/config/cassandra.yaml.erb
@@ -68,3 +68,19 @@ dynamic_snitch_badness_threshold: <%=properties.cassandra_seed.dynamic_snitch_ba
 request_scheduler: <%=properties.cassandra_seed.request_scheduler%>
 internode_compression: <%=properties.cassandra_seed.internode_compression%>
 inter_dc_tcp_nodelay: <%=properties.cassandra_seed.inter_dc_tcp_nodelay%>
+server_encryption_options:
+ internode_encryption: none
+ keystore: /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_cassandra.keystore
+ keystore_password: <%=properties.cassandra_seed.cass_KSP%>
+ truststore: /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_cassandra.truststore
+ truststore_password: <%=properties.cassandra_seed.cass_KSP%>
+ protocol: TLS
+client_encryption_options:
+ enabled: false
+ optional: true
+ keystore: /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_cassandra.keystore
+ keystore_password: <%=properties.cassandra_seed.cass_KSP%>
+ truststore: /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_cassandra.keystore
+ truststore_password: <%=properties.cassandra_seed.cass_KSP%>
+ require_client_auth: true
+ protocol: TLS

--- a/jobs/cassandra_seed/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra_seed/templates/config/cassandra.yaml.erb
@@ -66,21 +66,20 @@ dynamic_snitch_update_interval_in_ms: <%=properties.cassandra_seed.dynamic_snitc
 dynamic_snitch_reset_interval_in_ms: <%=properties.cassandra_seed.dynamic_snitch_reset_interval_in_ms%>
 dynamic_snitch_badness_threshold: <%=properties.cassandra_seed.dynamic_snitch_badness_threshold%>
 request_scheduler: <%=properties.cassandra_seed.request_scheduler%>
-internode_compression: <%=properties.cassandra_seed.internode_compression%>
 inter_dc_tcp_nodelay: <%=properties.cassandra_seed.inter_dc_tcp_nodelay%>
 server_encryption_options:
- internode_encryption: none
+ internode_encryption: <%=properties.cassandra_seed.server_encryption_options.internode_encryption%>
  keystore: /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_cassandra.keystore
  keystore_password: <%=properties.cassandra_seed.cass_KSP%>
  truststore: /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_cassandra.truststore
  truststore_password: <%=properties.cassandra_seed.cass_KSP%>
  protocol: TLS
 client_encryption_options:
- enabled: false
- optional: true
+ enabled: <%=properties.cassandra_seed.client_encryption_options.enabled%>
+##  optional: <%=properties.cassandra_seed.client_encryption_options.optional%>
  keystore: /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_cassandra.keystore
  keystore_password: <%=properties.cassandra_seed.cass_KSP%>
  truststore: /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_cassandra.keystore
  truststore_password: <%=properties.cassandra_seed.cass_KSP%>
- require_client_auth: true
+ require_client_auth: <%=properties.cassandra_seed.client_encryption_options.require_client_auth%>
  protocol: TLS

--- a/jobs/cassandra_seed/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra_seed/templates/config/cassandra.yaml.erb
@@ -79,7 +79,7 @@ client_encryption_options:
 ##  optional: <%=properties.cassandra_seed.client_encryption_options.optional%>
  keystore: /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_cassandra.keystore
  keystore_password: <%=properties.cassandra_seed.cass_KSP%>
- truststore: /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_cassandra.keystore
+ truststore: /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_cassandra.truststore
  truststore_password: <%=properties.cassandra_seed.cass_KSP%>
  require_client_auth: <%=properties.cassandra_seed.client_encryption_options.require_client_auth%>
  protocol: TLS

--- a/jobs/cassandra_seed/templates/config/cqlshrc.erb
+++ b/jobs/cassandra_seed/templates/config/cqlshrc.erb
@@ -1,0 +1,23 @@
+[authentication]
+username = cassandra
+password = <%=properties.cassandra_seed.cass_pwd%>
+;;keyspace = 
+
+
+[connection]
+hostname = <%=spec.ip%>
+port = 9042
+ssl = <%=properties.cassandra_seed.cassandra_ssl_YN%>
+request_timeout = 1800
+
+[ssl]
+certfile = /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_<%=properties.cassandra_seed.cluster_name%>_CLIENT.cer.pem
+validate = <%=properties.cassandra_seed.validate_ssl_TF%>
+userkey = /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_<%=properties.cassandra_seed.cluster_name%>_CLIENT.key.pem
+usercert = /var/vcap/jobs/cassandra_seed/config/certs/<%=spec.ip%>_<%=properties.cassandra_seed.cluster_name%>_CLIENT.cer.pem
+
+;; Optional section, overrides default certfile in [ssl] section, if present
+; [certfiles]
+; 192.168.1.3 = ~/keys/cassandra01.cert
+; 192.168.1.4 = ~/keys/cassandra02.cert
+

--- a/jobs/cassandra_seed/templates/helpers/ctl_setup.sh
+++ b/jobs/cassandra_seed/templates/helpers/ctl_setup.sh
@@ -95,5 +95,7 @@ fi
 mkdir -p $JOB_DIR/tools/bin/graph
 chmod 777 $JOB_DIR/tools/bin/graph
 chmod +x  $JOB_DIR/tools/bin/cassandra-stress.sh
+mkdir -p $JOB_DIR/ssl
+
 
 mount -o remount ,exec,suid,nodev /tmp

--- a/jobs/cassandra_seed/templates/helpers/ctl_setup.sh
+++ b/jobs/cassandra_seed/templates/helpers/ctl_setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+#set -x
 # Setup env vars and folders for the ctl script
 # This helps keep the ctl script as readable
 # as possible
@@ -96,6 +96,18 @@ mkdir -p $JOB_DIR/tools/bin/graph
 chmod 777 $JOB_DIR/tools/bin/graph
 chmod +x  $JOB_DIR/tools/bin/cassandra-stress.sh
 mkdir -p $JOB_DIR/ssl
+chmod +x $JOB_DIR/config/certs/ssl_env.ctl
+chmod +x $JOB_DIR/config/certs/gen_keystore_client.sh
 
+if [[ -d ${JOB_DIR}/config/certs/newcerts ]]
+then
+ rm -rf $JOB_DIR/config/certs/newcerts/
+ mkdir -p $JOB_DIR/config/certs/newcerts
+else 
+ mkdir -p $JOB_DIR/config/certs/newcerts
+fi
+
+chown vcap:vcap ${JOB_DIR}/config/certs/newcerts
+chown vcap:vcap ${JOB_DIR}/config/certs/
 
 mount -o remount ,exec,suid,nodev /tmp

--- a/jobs/cassandra_seed/templates/ssl/cassandradb.ca.erb
+++ b/jobs/cassandra_seed/templates/ssl/cassandradb.ca.erb
@@ -1,0 +1,1 @@
+<%= p("cassandra_seed.cassDbCertificate.ca") -%>

--- a/jobs/cassandra_seed/templates/ssl/cassandradb.pem.erb
+++ b/jobs/cassandra_seed/templates/ssl/cassandradb.pem.erb
@@ -1,0 +1,2 @@
+<%= p("cassandra_seed.cassDbCertificate.certificate") -%>
+<%= p("cassandra_seed.cassDbCertificate.private_key") -%>

--- a/jobs/cassandra_seed/templates/ssl2/cert
+++ b/jobs/cassandra_seed/templates/ssl2/cert
@@ -1,0 +1,1 @@
+<%= p("cassandra_seed.cert.certificate") %>

--- a/jobs/cassandra_seed/templates/ssl2/cert_ca
+++ b/jobs/cassandra_seed/templates/ssl2/cert_ca
@@ -1,0 +1,1 @@
+<%= p("cassandra_seed.cert.ca") %>

--- a/jobs/cassandra_seed/templates/ssl2/cert_private_key
+++ b/jobs/cassandra_seed/templates/ssl2/cert_private_key
@@ -1,0 +1,1 @@
+<%= p("cassandra_seed.cert.private_key") %>

--- a/jobs/cassandra_seed/templates/ssl2/gen_ca_cert.conf
+++ b/jobs/cassandra_seed/templates/ssl2/gen_ca_cert.conf
@@ -1,0 +1,35 @@
+[ ca ]
+default_ca =internalCA
+[ internalCA ]
+dir =/var/vcap/packages/cassandra_seed/config/certs/
+certificate = $dir/ca.cert
+database = $dir/index.txt
+serial = $dir/serial
+new_certs_dir = $dir/newcerts
+private_key = $dir/node.key
+default_days = 365
+default_md = md5
+policy = CAuser_policy
+
+[ CAuser_policy ]
+stateOrProvinceName = optional
+countryName = supplied
+organizationName = supplied
+organizationalUnitName =optional
+commonName = supplied
+
+[ req ]
+distinguished_name = req_cassandra
+prompt = no
+default_bits = 2048
+default_keyfile = $dir/node.key
+
+[ req_cassandra ]
+C = FR
+ST = FR
+L = LYON
+O = Orange
+OU = TestCluster
+CN = `hostname -I`
+emailAddress = omer.missoum@orange.com
+

--- a/jobs/cassandra_seed/templates/ssl2/gen_keystore_client.sh
+++ b/jobs/cassandra_seed/templates/ssl2/gen_keystore_client.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+cd /var/vcap/jobs/cassandra_seed/config/certs/
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin:.
+
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+export STOREPASS="<%=properties.cassandra_seed.cass_KSP%>"
+export KEYPASS=$STOREPASS
+keytool -genkeypair -keyalg RSA -alias ${HOST_NAME} -keystore ${HOST_NAME}.jks -storepass $STOREPASS -keypass $KEYPASS -validity 3650 -keysize 2048 -dname "CN=${HOST_NAME}, OU=TestCluster, O=Orange, L=Lyon, S=FR, C=FR"
+
+keytool -keystore ${HOST_NAME}.jks -alias ${HOST_NAME} -certreq -file ${HOST_NAME}.csr -keypass $KEYPASS -storepass $STOREPASS
+exit 0

--- a/jobs/cassandra_seed/templates/ssl2/ssl_env.ctl.erb
+++ b/jobs/cassandra_seed/templates/ssl2/ssl_env.ctl.erb
@@ -1,0 +1,21 @@
+#!/bin/bash
+#set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin
+export IN_OU_CERT_REQ=/var/vcap/jobs/cassandra_seed/config/certs/
+export CA_CERT_PEM=/var/vcap/jobs/cassandra_seed/config/certs/cert
+
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+
+pushd /var/vcap/jobs/cassandra_seed/config/certs/
+exec chpst -u vcap:vcap /var/vcap/jobs/cassandra_seed/config/certs/./gen_keystore_client.sh 
+popd
+
+openssl ca -config ${IN_OU_CERT_REQ}/gen_ca_cert.conf -in ${IN_OU_CERT_REQ}/${HOST_NAME}.csr
+
+exit 0

--- a/jobs/cassandra_seed/templates/ssl3/gen_keystore_client.sh
+++ b/jobs/cassandra_seed/templates/ssl3/gen_keystore_client.sh
@@ -48,6 +48,16 @@ keytool -importkeystore \
     -destkeystore "$KEY_STORE"
 
 
+keytool -import -v \
+    -trustcacerts \
+    -alias /internalCA \
+    -file "$JOB_DIR/config/certs/ca.crt" \
+    -keystore "$TRUST_STORE" \
+    -storepass "$PASSWORD" \
+    -keypass "$PASSWORD" \
+    -noprompt
+
+
 exit 0
 
 

--- a/jobs/cassandra_seed/templates/ssl3/gen_keystore_client.sh
+++ b/jobs/cassandra_seed/templates/ssl3/gen_keystore_client.sh
@@ -22,43 +22,73 @@ export KEYPASS=$STOREPASS
 export PASSWORD=$KEYPASS
 
 
-### Cluster key setup.
-# Create the cluster key for cluster communication.
-keytool -genkey -keyalg RSA -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
--dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
--validity 36500
 
-# Create the public key for the cluster which is used to identify nodes.
-keytool -export -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$KEY_STORE" \
--storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
-
-# Import the identity of the cluster public cluster key into the trust store so that nodes can identify each other.
-keytool -import -v -trustcacerts -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$TRUST_STORE" \
--storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
-
-
-### Client key setup.
-# Create the client key for CQL.
-keytool -genkey -keyalg RSA -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
--dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
--validity 36500
-
-# Create the public key for the client to identify itself.
-keytool -export -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$KEY_STORE" \
--storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
-
-# Import the identity of the client pub  key into the trust store so nodes can identify this client.
-keytool -importcert -v -trustcacerts -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$TRUST_STORE" \
--storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+openssl pkcs12 -export \
+    -in "$JOB/config/certs/node.crt" \
+    -inkey "$JOB/config/certs/node.key" \
+    -name "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" \
+    \
+    -CAfile "$JOB/config/certs/ca.crt" \
+    -caname /internalCA \
+    \
+    -out "$JOB/config/keystore.p12" \
+    -passout "pass:$PASSWORD"
 
 
 
-keytool -importkeystore -srckeystore "$KEY_STORE" -destkeystore "$PKS_KEY_STORE" -deststoretype PKCS12 \
--srcstorepass "$PASSWORD" -deststorepass "$PASSWORD"
 
-openssl pkcs12 -in "$PKS_KEY_STORE" -nokeys -out "${HOST_NAME}_${CLUSTER_NAME}_CLIENT.cer.pem" -passin pass:"$PASSWORD"
-openssl pkcs12 -in "$PKS_KEY_STORE" -nodes -nocerts -out "${HOST_NAME}_${CLUSTER_NAME}_CLIENT.key.pem" -passin pass:"$PASSWORD"
+keytool -importkeystore \
+    -srckeystore "$JOB/config/keystore.p12" \
+    -srcstoretype PKCS12 \
+    -srcstorepass "$PASSWORD" \
+    -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" \
+    \
+    -deststorepass "$PASSWORD" \
+    -destkeypass "$PASSWORD" \
+    -destkeystore "$KEY_STORE"
 
 
 exit 0
+
+
+
+# ### Cluster key setup.
+# # Create the cluster key for cluster communication.
+# keytool -genkey -keyalg RSA -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+# -dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
+# -validity 36500
+
+# # Create the public key for the cluster which is used to identify nodes.
+# keytool -export -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$KEY_STORE" \
+# -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+# # Import the identity of the cluster public cluster key into the trust store so that nodes can identify each other.
+# keytool -import -v -trustcacerts -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+# -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+
+# ### Client key setup.
+# # Create the client key for CQL.
+# keytool -genkey -keyalg RSA -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+# -dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
+# -validity 36500
+
+# # Create the public key for the client to identify itself.
+# keytool -export -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$KEY_STORE" \
+# -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+# # Import the identity of the client pub  key into the trust store so nodes can identify this client.
+# keytool -importcert -v -trustcacerts -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+# -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+
+
+# keytool -importkeystore -srckeystore "$KEY_STORE" -destkeystore "$PKS_KEY_STORE" -deststoretype PKCS12 \
+# -srcstorepass "$PASSWORD" -deststorepass "$PASSWORD"
+
+# openssl pkcs12 -in "$PKS_KEY_STORE" -nokeys -out "${HOST_NAME}_${CLUSTER_NAME}_CLIENT.cer.pem" -passin pass:"$PASSWORD"
+# openssl pkcs12 -in "$PKS_KEY_STORE" -nodes -nocerts -out "${HOST_NAME}_${CLUSTER_NAME}_CLIENT.key.pem" -passin pass:"$PASSWORD"
+
+
+# exit 0
 

--- a/jobs/cassandra_seed/templates/ssl3/gen_keystore_client.sh
+++ b/jobs/cassandra_seed/templates/ssl3/gen_keystore_client.sh
@@ -7,15 +7,16 @@ cd ${KEY_STORE_PATH}
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:$JAVA_HOME/bin:.
 
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+
 export KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.keystore"
 export PKS_KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.pks12.keystore"
 export TRUST_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.truststore"
 export CLUSTER_NAME="<%=properties.cassandra_seed.cluster_name%>"
-export CLUSTER_PUBLIC_CERT="$KEY_STORE_PATH/CLUSTER_${CLUSTER_NAME}_PUBLIC.cer"
-export CLIENT_PUBLIC_CERT="$KEY_STORE_PATH/CLIENT_${CLUSTER_NAME}_PUBLIC.cer"
+export CLUSTER_PUBLIC_CERT="$KEY_STORE_PATH/${HOST_NAME}_CLUSTER_${CLUSTER_NAME}_PUBLIC.cer"
+export CLIENT_PUBLIC_CERT="$KEY_STORE_PATH/${HOST_NAME}_CLIENT_${CLUSTER_NAME}_PUBLIC.cer"
 
-export HOST_NAME1=`hostname -I`
-export HOST_NAME=${HOST_NAME1//[[:space:]]}
 export STOREPASS="<%=properties.cassandra_seed.cass_KSP%>"
 export KEYPASS=$STOREPASS
 export PASSWORD=$KEYPASS
@@ -23,31 +24,31 @@ export PASSWORD=$KEYPASS
 
 ### Cluster key setup.
 # Create the cluster key for cluster communication.
-keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLUSTER" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+keytool -genkey -keyalg RSA -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
 -dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
 -validity 36500
 
 # Create the public key for the cluster which is used to identify nodes.
-keytool -export -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$KEY_STORE" \
+keytool -export -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$KEY_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
 
 # Import the identity of the cluster public cluster key into the trust store so that nodes can identify each other.
-keytool -import -v -trustcacerts -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+keytool -import -v -trustcacerts -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$TRUST_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
 
 
 ### Client key setup.
 # Create the client key for CQL.
-keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLIENT" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+keytool -genkey -keyalg RSA -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
 -dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
 -validity 36500
 
 # Create the public key for the client to identify itself.
-keytool -export -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$KEY_STORE" \
+keytool -export -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$KEY_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
 
 # Import the identity of the client pub  key into the trust store so nodes can identify this client.
-keytool -importcert -v -trustcacerts -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+keytool -importcert -v -trustcacerts -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$TRUST_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
 
 
@@ -55,8 +56,8 @@ keytool -importcert -v -trustcacerts -alias "${CLUSTER_NAME}_CLIENT" -file "$CLI
 keytool -importkeystore -srckeystore "$KEY_STORE" -destkeystore "$PKS_KEY_STORE" -deststoretype PKCS12 \
 -srcstorepass "$PASSWORD" -deststorepass "$PASSWORD"
 
-openssl pkcs12 -in "$PKS_KEY_STORE" -nokeys -out "${CLUSTER_NAME}_CLIENT.cer.pem" -passin pass:"$PASSWORD"
-openssl pkcs12 -in "$PKS_KEY_STORE" -nodes -nocerts -out "${CLUSTER_NAME}_CLIENT.key.pem" -passin pass:"$PASSWORD"
+openssl pkcs12 -in "$PKS_KEY_STORE" -nokeys -out "${HOST_NAME}_${CLUSTER_NAME}_CLIENT.cer.pem" -passin pass:"$PASSWORD"
+openssl pkcs12 -in "$PKS_KEY_STORE" -nodes -nocerts -out "${HOST_NAME}_${CLUSTER_NAME}_CLIENT.key.pem" -passin pass:"$PASSWORD"
 
 
 exit 0

--- a/jobs/cassandra_seed/templates/ssl3/gen_keystore_client.sh
+++ b/jobs/cassandra_seed/templates/ssl3/gen_keystore_client.sh
@@ -21,24 +21,24 @@ export STOREPASS="<%=properties.cassandra_seed.cass_KSP%>"
 export KEYPASS=$STOREPASS
 export PASSWORD=$KEYPASS
 
-
+export JOB_DIR=/var/vcap/jobs/cassandra_seed
 
 openssl pkcs12 -export \
-    -in "$JOB/config/certs/node.crt" \
-    -inkey "$JOB/config/certs/node.key" \
+    -in "$JOB_DIR/config/certs/node.crt" \
+    -inkey "$JOB_DIR/config/certs/node.key" \
     -name "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" \
     \
-    -CAfile "$JOB/config/certs/ca.crt" \
+    -CAfile "$JOB_DIR/config/certs/ca.crt" \
     -caname /internalCA \
     \
-    -out "$JOB/config/keystore.p12" \
+    -out "$JOB_DIR/config/certs/keystore.p12" \
     -passout "pass:$PASSWORD"
 
 
 
 
 keytool -importkeystore \
-    -srckeystore "$JOB/config/keystore.p12" \
+    -srckeystore "$JOB_DIR/config/certs/keystore.p12" \
     -srcstoretype PKCS12 \
     -srcstorepass "$PASSWORD" \
     -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" \

--- a/jobs/cassandra_seed/templates/ssl3/gen_keystore_client.sh
+++ b/jobs/cassandra_seed/templates/ssl3/gen_keystore_client.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+export KEY_STORE_PATH=/var/vcap/jobs/cassandra_seed/config/certs/
+cd ${KEY_STORE_PATH}
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin:.
+
+export KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.keystore"
+export PKS_KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.pks12.keystore"
+export TRUST_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.truststore"
+export CLUSTER_NAME="<%=properties.cassandra_seed.cluster_name%>"
+export CLUSTER_PUBLIC_CERT="$KEY_STORE_PATH/CLUSTER_${CLUSTER_NAME}_PUBLIC.cer"
+export CLIENT_PUBLIC_CERT="$KEY_STORE_PATH/CLIENT_${CLUSTER_NAME}_PUBLIC.cer"
+
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+export STOREPASS="<%=properties.cassandra_seed.cass_KSP%>"
+export KEYPASS=$STOREPASS
+export PASSWORD=$KEYPASS
+
+
+### Cluster key setup.
+# Create the cluster key for cluster communication.
+keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLUSTER" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+-dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
+-validity 36500
+
+# Create the public key for the cluster which is used to identify nodes.
+keytool -export -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$KEY_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+# Import the identity of the cluster public cluster key into the trust store so that nodes can identify each other.
+keytool -import -v -trustcacerts -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+
+### Client key setup.
+# Create the client key for CQL.
+keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLIENT" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+-dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
+-validity 36500
+
+# Create the public key for the client to identify itself.
+keytool -export -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$KEY_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+# Import the identity of the client pub  key into the trust store so nodes can identify this client.
+keytool -importcert -v -trustcacerts -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+
+
+keytool -importkeystore -srckeystore "$KEY_STORE" -destkeystore "$PKS_KEY_STORE" -deststoretype PKCS12 \
+-srcstorepass "$PASSWORD" -deststorepass "$PASSWORD"
+
+openssl pkcs12 -in "$PKS_KEY_STORE" -nokeys -out "${CLUSTER_NAME}_CLIENT.cer.pem" -passin pass:"$PASSWORD"
+openssl pkcs12 -in "$PKS_KEY_STORE" -nodes -nocerts -out "${CLUSTER_NAME}_CLIENT.key.pem" -passin pass:"$PASSWORD"
+
+
+exit 0
+

--- a/jobs/cassandra_seed/templates/ssl3/ssl_env.ctl.erb
+++ b/jobs/cassandra_seed/templates/ssl3/ssl_env.ctl.erb
@@ -1,0 +1,22 @@
+#!/bin/bash
+#set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin
+export IN_OU_CERT_REQ=/var/vcap/jobs/cassandra_seed/config/certs/
+export CA_CERT_PEM=/var/vcap/jobs/cassandra_seed/config/certs/cert
+
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_seed/conf
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+
+pushd /var/vcap/jobs/cassandra_seed/config/certs/
+exec chpst -u vcap:vcap /var/vcap/jobs/cassandra_seed/config/certs/./gen_keystore_client.sh
+popd
+
+#openssl ca -config ${IN_OU_CERT_REQ}/gen_ca_cert.conf -in ${IN_OU_CERT_REQ}/${HOST_NAME}.csr
+
+exit 0
+

--- a/jobs/cassandra_seed/templates/ssl3/ssl_env.ctl.erb
+++ b/jobs/cassandra_seed/templates/ssl3/ssl_env.ctl.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-set -e # exit immediately if a simple command exits with a non-zero status.
+#set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
 
 export JAVA_HOME=/var/vcap/packages/openjdk

--- a/jobs/cassandra_server/spec
+++ b/jobs/cassandra_server/spec
@@ -3,15 +3,12 @@ name: cassandra_server
 packages:
 - cassandra
 - openjdk
-provides:
-- name: seeds
-  type: cassandra_servers
 consumes:
 - name: seeds
-  type: cassandra_servers
+  type: cassandra_seeds
 
 templates:
-  bin/cassandra_server.ctl: bin/cassandra_server_ctl
+  bin/cassandra_server_ctl: bin/cassandra_server_ctl
   bin/monit_debugger: bin/monit_debugger
   bin/node-tool.sh: bin/node-tool.sh
   bin/cql-sh.sh: bin/cql-sh.sh

--- a/jobs/cassandra_server/spec
+++ b/jobs/cassandra_server/spec
@@ -28,7 +28,6 @@ templates:
   config/logback.xml.erb: conf/logback.xml
   config/logback-tools.xml.erb: conf/logback-tools.xml
   config/commitlog_archiving.properties.erb: conf/commitlog_archiving.properties
-  config/cqlshrc.sample.erb: conf/cqlshrc.sample
 #  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
 #  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
 #  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
@@ -38,6 +37,7 @@ templates:
 #  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
 #  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
 #  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
+  config/cqlshrc.erb: /root/.cassandra/cqlshrc
   ssl3/ssl_env.ctl.erb: config/certs/ssl_env.ctl
   ssl3/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
@@ -257,3 +257,15 @@ properties:
   cassandra_server.cass_KSP:
     default:
     description: cassandra ssl keystore passwd
+  cassandra_server.validate_ssl_TF:
+    default: false
+    description: cassandra ssl validate true or false
+  cassandra_server.server_encryption_options.internode_encryption:
+    default: false
+    description: cassandra ssl entre noeuds true or false
+  cassandra_server.client_encryption_options.enabled:
+    default: false
+    description: cassandra ssl entre client et server true or false
+  cassandra_server.client_encryption_options.require_client_auth:
+    default: false
+    description: cassandra ssl entre client et server et authentifi

--- a/jobs/cassandra_server/spec
+++ b/jobs/cassandra_server/spec
@@ -32,12 +32,14 @@ templates:
 #  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
 #  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
 #  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
-  ssl2/cert: config/certs/node.crt
-  ssl2/cert_ca: config/certs/ca.crt
-  ssl2/cert_private_key: config/certs/node.key
-  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
-  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
-  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
+#  ssl2/cert: config/certs/node.crt
+#  ssl2/cert_ca: config/certs/ca.crt
+#  ssl2/cert_private_key: config/certs/node.key
+#  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
+#  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
+#  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
+  ssl3/ssl_env.ctl.erb: config/certs/ssl_env.ctl
+  ssl3/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
   bin/creer_pem_cli_serv.sh: bin/creer_pem_cli_serv.sh

--- a/jobs/cassandra_server/spec
+++ b/jobs/cassandra_server/spec
@@ -34,6 +34,7 @@ templates:
   ssl/cassandradb.pem.erb: ssl/cassandradb.pem
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
+  bin/creer_pem_cli_serv.sh: bin/creer_pem_cli_serv.sh
   bin/sec-sysauth.sh: bin/post-start
 
 properties:
@@ -236,8 +237,8 @@ properties:
     description:
   cassandra_server.cass_pwd:
     default: cassandra
-  cassandra_server.cassConf_ssl:
-    default: 1
+  cassandra_server.cassandra_ssl_YN:
+    default: N
     description: use tls/ssl for authent and transactions 
   cassandra_server.cassDbCertificate:
     default: "NOT INITIALIZED"

--- a/jobs/cassandra_server/spec
+++ b/jobs/cassandra_server/spec
@@ -3,11 +3,15 @@ name: cassandra_server
 packages:
 - cassandra
 - openjdk
+provides:
+- name: seeds
+  type: cassandra_servers
 consumes:
 - name: seeds
-  type: cassandra_seeds
+  type: cassandra_servers
+
 templates:
-  bin/cassandra_server_ctl: bin/cassandra_server_ctl
+  bin/cassandra_server.ctl: bin/cassandra_server_ctl
   bin/monit_debugger: bin/monit_debugger
   bin/node-tool.sh: bin/node-tool.sh
   bin/cql-sh.sh: bin/cql-sh.sh
@@ -28,6 +32,9 @@ templates:
   config/logback-tools.xml.erb: conf/logback-tools.xml
   config/commitlog_archiving.properties.erb: conf/commitlog_archiving.properties
   config/cqlshrc.sample.erb: conf/cqlshrc.sample
+  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
+  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
+  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
   bin/sec-sysauth.sh: bin/post-start
@@ -55,10 +62,10 @@ properties:
     default: PasswordAuthenticator 
     description: AllowAllAuthenticator c.a.d pas de controle sinon possible avec  PasswordAuthenticator.
   cassandra_server.authorizer:
-    default: CassandraAuthorizer 
+    default: CassandraAuthorizer
     description: pour gerer les droits dans la bdd. Controle fin avec CassandraAuthorizer.
   cassandra_server.permissions_validity_in_ms:
-    default: 2000 
+    default: 4000 
     description: duree de validite des permissions stockees en cache.Se desactive en positionnant a 0 avec AllowAllAuthorizer.
   cassandra_server.partitioner:
     default: org.apache.cassandra.dht.Murmur3Partitioner 
@@ -226,10 +233,15 @@ properties:
     default: 8G
     description:
   cassandra_server.heap_newsize:
-    default: 1G 
+    default: 1G
     description:
   cassandra_server.topology:
     description:
   cassandra_server.cass_pwd:
     default: cassandra
-
+  cassandra_server.cassConf_ssl:
+    default: 1
+    description: use tls/ssl for authent and transactions 
+  cassandra_server.cassDbCertificate:
+    default: "NOT INITIALIZED"
+    description: use tls/ssl for authent and transactions 

--- a/jobs/cassandra_server/spec
+++ b/jobs/cassandra_server/spec
@@ -29,9 +29,15 @@ templates:
   config/logback-tools.xml.erb: conf/logback-tools.xml
   config/commitlog_archiving.properties.erb: conf/commitlog_archiving.properties
   config/cqlshrc.sample.erb: conf/cqlshrc.sample
-  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
-  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
-  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
+#  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
+#  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
+#  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
+  ssl2/cert: config/certs/node.crt
+  ssl2/cert_ca: config/certs/ca.crt
+  ssl2/cert_private_key: config/certs/node.key
+  ssl2/ssl_env.ctl.erb: config/certs/ssl_env.ctl
+  ssl2/gen_keystore_client.sh: config/certs/gen_keystore_client.sh
+  ssl2/gen_ca_cert.conf: config/certs/gen_ca_cert.conf
   bin/ops-admin/operation-tool.sh: bin/ops-admin/operation-tool.sh
   bin/ops-admin/cassandra.conf: bin/ops-admin/cassandra.conf
   bin/creer_pem_cli_serv.sh: bin/creer_pem_cli_serv.sh
@@ -243,3 +249,9 @@ properties:
   cassandra_server.cassDbCertificate:
     default: "NOT INITIALIZED"
     description: use tls/ssl for authent and transactions 
+  cassandra_server.cert:
+    type: certficate
+    description: cluster certificate
+  cassandra_server.cass_KSP:
+    default:
+    description: cassandra ssl keystore passwd

--- a/jobs/cassandra_server/templates/bin/cassandra_server_ctl
+++ b/jobs/cassandra_server/templates/bin/cassandra_server_ctl
@@ -16,6 +16,8 @@ export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:/var/vcap/packages/openjdk/bin
 
+#sudo swapoff -a
+
 case $1 in
 
   start)
@@ -32,7 +34,7 @@ case $1 in
 
     ;;
   *)
-    echo "Usage: cassandra_server_ctl {start|stop}"
+    echo "Usage: cassandra_server.ctl {start|stop}"
 
     ;;
 

--- a/jobs/cassandra_server/templates/bin/cql-sh.sh
+++ b/jobs/cassandra_server/templates/bin/cql-sh.sh
@@ -13,7 +13,18 @@ export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF
 
 ## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 
-pushd /var/vcap/packages/cassandra/bin
-exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/cqlsh "$@"
-popd
-exit 0
+export CLIENT_SSL=<%=properties.cassandra_server.client_encryption_options.enabled%>
+
+if [[ ${CLIENT_SSL} == "true" ]]
+then
+ pushd /var/vcap/packages/cassandra/bin
+ exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc" "$@" --ssl
+ popd
+ exit 0
+else
+ pushd /var/vcap/packages/cassandra/bin
+ exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/cqlsh "$@"
+ popd
+ exit 0
+fi
+

--- a/jobs/cassandra_server/templates/bin/creer_pem_cli_serv.sh
+++ b/jobs/cassandra_server/templates/bin/creer_pem_cli_serv.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
+export CASSANDRA_SSL=/var/vcap/jobs/cassandra_server/ssl
+cd ${CASSANDRA_SSL}
+
+export SSL_YN=<%=properties.cassandra_server.cassandra_ssl_YN%>
+
+if ${SSL_YN} == "Y" 
+then
+ /var/vcap/jobs/cassandra_server/bin/./generate_ssl_cert.sh
+fi
+
+popd >/dev/null
+exit 0

--- a/jobs/cassandra_server/templates/bin/creer_pem_cli_serv.sh
+++ b/jobs/cassandra_server/templates/bin/creer_pem_cli_serv.sh
@@ -4,14 +4,14 @@ set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
 
 pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
-export CASSANDRA_SSL=/var/vcap/jobs/cassandra_server/ssl
+export CASSANDRA_SSL=/var/vcap/jobs/cassandra_server/config/certs
 cd ${CASSANDRA_SSL}
 
 export SSL_YN=<%=properties.cassandra_server.cassandra_ssl_YN%>
 
 if ${SSL_YN} == "Y" 
 then
- /var/vcap/jobs/cassandra_server/bin/./generate_ssl_cert.sh
+ /var/vcap/jobs/cassandra_server/config/certs/./ssl_env.ctl
 fi
 
 popd >/dev/null

--- a/jobs/cassandra_server/templates/bin/generate_ssl_cert.sh
+++ b/jobs/cassandra_server/templates/bin/generate_ssl_cert.sh
@@ -5,7 +5,7 @@ set -u # report the usage of uninitialized variables.
 
 #source `dirname $(readlink --canonicalize-existing $0)`/setenv
 
-#pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
+pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
 export CASSANDRA_SSL=/var/vcap/jobs/cassandra_server/ssl
 cd ${CASSANDRA_SSL}
 
@@ -35,5 +35,5 @@ then
 	rm *.req *.srl *.crt *.key .rnd
 fi
 
-# popd >/dev/null
+popd >/dev/null
 exit 0

--- a/jobs/cassandra_server/templates/bin/generate_ssl_cert.sh
+++ b/jobs/cassandra_server/templates/bin/generate_ssl_cert.sh
@@ -27,7 +27,7 @@ then
 
 	openssl genrsa -out client.key 2048
 	openssl req -key client.key -new -out client.req -subj "/C=FR/ST=IDF/O=Cloud Foundry/CN=${node_current_ip}/emailAddress=user@domain.com"
-	openssl x509 -req -in client.req -CA cassandradb.ca -CAkey cassandra.pem -CAserial cassandradb.srl -out client.crt -days 3650
+	openssl x509 -req -in client.req -CA cassandradb.ca -CAkey cassandradb.pem -CAserial cassandradb.srl -out client.crt -days 3650
 	cat client.key client.crt > client.pem
 	#openssl verify -CAfile cassandradb.ca client.pem
 
@@ -35,5 +35,5 @@ then
 	rm *.req *.srl *.crt *.key .rnd
 fi
 
-popd >/dev/null
+# popd >/dev/null
 exit 0

--- a/jobs/cassandra_server/templates/bin/generate_ssl_cert.sh
+++ b/jobs/cassandra_server/templates/bin/generate_ssl_cert.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+#source `dirname $(readlink --canonicalize-existing $0)`/setenv
+
+#pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
+export CASSANDRA_SSL=/var/vcap/jobs/cassandra_server/ssl
+cd ${CASSANDRA_SSL}
+
+#[ -f server.pem ] && rm -f server.pem 
+#[ -f client.pem ] && rm -f client.pem
+
+touch .rnd
+export RANDFILE="${CASSANDRA_SSL}"/.rnd
+
+# generate only if client and server keys doesnt already exists
+if [ ! -f server.pem -o ! -f client.pem ]
+then
+	node_current_ip=`hostname -I`
+	perl -e 'my $n1=int(rand(10));my $n2=int(rand(10));print "$n1$n2\n"' > cassandradb.srl # two random digits number
+	openssl genrsa -out server.key 2048
+	openssl req -key server.key -new -out server.req -subj  "/C=FR/ST=IDF/O=Cloud Foundry/CN=${node_current_ip}/emailAddress=user@domain.com"
+	openssl x509 -req -in server.req -CA cassandradb.ca -CAkey cassandradb.pem -CAserial cassandradb.srl -out server.crt -days 3650
+	cat server.key server.crt > server.pem
+
+	openssl genrsa -out client.key 2048
+	openssl req -key client.key -new -out client.req -subj "/C=FR/ST=IDF/O=Cloud Foundry/CN=${node_current_ip}/emailAddress=user@domain.com"
+	openssl x509 -req -in client.req -CA cassandradb.ca -CAkey cassandra.pem -CAserial cassandradb.srl -out client.crt -days 3650
+	cat client.key client.crt > client.pem
+	#openssl verify -CAfile cassandradb.ca client.pem
+
+	# removing unneeded files
+	rm *.req *.srl *.crt *.key .rnd
+fi
+
+popd >/dev/null
+exit 0

--- a/jobs/cassandra_server/templates/bin/sec-sysauth.sh
+++ b/jobs/cassandra_server/templates/bin/sec-sysauth.sh
@@ -14,7 +14,25 @@ export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF
 export CASS_PWD="<%=properties.cassandra_server.cass_pwd%>"
 ## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 
-export CLIENT_SSL=<%properties.cassandra_server.client_encryption_options.enabled%>
+export CLIENT_SSL=<%=properties.cassandra_server.client_encryption_options.enabled%>
+
+if ${CLIENT_SSL} == "true"
+then
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra --ssl 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD --ssl 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD --ssl  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
+#exit 0
+else
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
+fi
 
 if ${CLIENT_SSL} == "true"
 then

--- a/jobs/cassandra_server/templates/bin/sec-sysauth.sh
+++ b/jobs/cassandra_server/templates/bin/sec-sysauth.sh
@@ -19,7 +19,7 @@ if [[ "$?" == 1 ]]; then
 /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
 fi
 /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
-/var/vcap/jobs/cassandra_seed/bin/./node-tool.sh repair system_auth
+/var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
 #exit 0
 
 /var/vcap/jobs/cassandra_server/bin/./creer_pem_cli_serv.sh

--- a/jobs/cassandra_server/templates/bin/sec-sysauth.sh
+++ b/jobs/cassandra_server/templates/bin/sec-sysauth.sh
@@ -14,13 +14,26 @@ export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF
 export CASS_PWD="<%=properties.cassandra_server.cass_pwd%>"
 ## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 
-/var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra 2>&1>/dev/null
-if [[ "$?" == 1 ]]; then
-/var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
-fi
-/var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
-/var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
+export CLIENT_SSL=<%properties.cassandra_server.client_encryption_options.enabled%>
+
+if ${CLIENT_SSL} == "true"
+then
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra --ssl 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD --ssl 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_server/root/.cassandra/cqlshrc"  -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD --ssl  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
 #exit 0
+else
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p cassandra 2>&1>/dev/null
+ if [[ "$?" == 1 ]]; then
+  /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter role cassandra with password = '$CASS_PWD' " -u cassandra -p $CASS_PWD 2>&1>/dev/null
+ fi
+ /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
+ /var/vcap/jobs/cassandra_server/bin/./node-tool.sh repair system_auth
+fi
 
 /var/vcap/jobs/cassandra_server/bin/./creer_pem_cli_serv.sh
 exit 0
+

--- a/jobs/cassandra_server/templates/bin/sec-sysauth.sh
+++ b/jobs/cassandra_server/templates/bin/sec-sysauth.sh
@@ -20,4 +20,7 @@ if [[ "$?" == 1 ]]; then
 fi
 /var/vcap/packages/cassandra/bin/cqlsh `hostname -I` -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '3'}  AND durable_writes = true" -u cassandra -p $CASS_PWD  2>&1>/dev/null
 /var/vcap/jobs/cassandra_seed/bin/./node-tool.sh repair system_auth
+#exit 0
+
+/var/vcap/jobs/cassandra_server/bin/./creer_pem_cli_serv.sh
 exit 0

--- a/jobs/cassandra_server/templates/bin/sstable-loader.sh
+++ b/jobs/cassandra_server/templates/bin/sstable-loader.sh
@@ -6,13 +6,13 @@ set -u # report the usage of uninitialized variables.
 export LANG=en_US.UTF-8
 
 export CASSANDRA_BIN=/var/vcap/packages/cassandra/bin
-export CASSANDRA_CONF=/var/vcap/jobs/cassandra_seed/conf
+export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 export CASSANDRA_TOOL=/var/vcap/packages/cassandra/tools/bin
 
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF:$CASSANDRA_TOOL
 export CASS_PWD="<%=properties.cassandra_server.cass_pwd%>"
-## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_seed/conf
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 
 pushd /var/vcap/packages/cassandra/tools/bin
 if [ $# -eq 0 ];

--- a/jobs/cassandra_server/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra_server/templates/config/cassandra.yaml.erb
@@ -69,7 +69,7 @@ request_scheduler: <%=properties.cassandra_server.request_scheduler%>
 internode_compression: <%=properties.cassandra_server.internode_compression%>
 inter_dc_tcp_nodelay: <%=properties.cassandra_server.inter_dc_tcp_nodelay%>
 server_encryption_options:
- internode_encryption: none
+ internode_encryption: <%=properties.cassandra_server.server_encryption_options.internode_encryption%>
  keystore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
  keystore_password: <%=properties.cassandra_server.cass_KSP%>
  truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.truststore
@@ -77,10 +77,10 @@ server_encryption_options:
  protocol: TLS
 client_encryption_options:
  enabled: false
- optional: true
+##  optional: <%=properties.cassandra_server.client_encryption_options.optional%>
  keystore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
  keystore_password: <%=properties.cassandra_server.cass_KSP%>
  truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
  truststore_password: <%=properties.cassandra_server.cass_KSP%>
- require_client_auth: true
+ require_client_auth: <%=properties.cassandra_server.client_encryption_options.require_client_auth%>
  protocol: TLS

--- a/jobs/cassandra_server/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra_server/templates/config/cassandra.yaml.erb
@@ -76,11 +76,11 @@ server_encryption_options:
  truststore_password: <%=properties.cassandra_server.cass_KSP%>
  protocol: TLS
 client_encryption_options:
- enabled: false
+ enabled: <%=properties.cassandra_server.client_encryption_options.enabled%>
 ##  optional: <%=properties.cassandra_server.client_encryption_options.optional%>
  keystore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
  keystore_password: <%=properties.cassandra_server.cass_KSP%>
- truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
+ truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.truststore
  truststore_password: <%=properties.cassandra_server.cass_KSP%>
  require_client_auth: <%=properties.cassandra_server.client_encryption_options.require_client_auth%>
  protocol: TLS

--- a/jobs/cassandra_server/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra_server/templates/config/cassandra.yaml.erb
@@ -68,3 +68,19 @@ dynamic_snitch_badness_threshold: <%=properties.cassandra_server.dynamic_snitch_
 request_scheduler: <%=properties.cassandra_server.request_scheduler%>
 internode_compression: <%=properties.cassandra_server.internode_compression%>
 inter_dc_tcp_nodelay: <%=properties.cassandra_server.inter_dc_tcp_nodelay%>
+server_encryption_options:
+ internode_encryption: none
+ keystore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
+ keystore_password: <%=properties.cassandra_server.cass_KSP%>
+ truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.truststore
+ truststore_password: <%=properties.cassandra_server.cass_KSP%>
+ protocol: TLS
+client_encryption_options:
+ enabled: false
+ optional: true
+ keystore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
+ keystore_password: <%=properties.cassandra_server.cass_KSP%>
+ truststore: /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_cassandra.keystore
+ truststore_password: <%=properties.cassandra_server.cass_KSP%>
+ require_client_auth: true
+ protocol: TLS

--- a/jobs/cassandra_server/templates/config/cqlshrc.erb
+++ b/jobs/cassandra_server/templates/config/cqlshrc.erb
@@ -1,20 +1,20 @@
 [authentication]
 username = cassandra
-password = <%=properties.cassandra_server.cass_KSP%>
+password = <%=properties.cassandra_server.cass_pwd%>
 ;;keyspace = 
 
 
 [connection]
-hostname = <%spec.ip%>
+hostname = <%=spec.ip%>
 port = 9042
-ssl = <%= properties.cassandra_server.cassandra_ssl_YN%>
+ssl = <%=properties.cassandra_server.cassandra_ssl_YN%>
 request_timeout = 1800
 
 [ssl]
-certfile = /var/vcap/jobs/cassandra_server/config/certs/<%spec.ip%>_<%=properties.cassandra_server.cluster_name%>_CLIENT.cer.pem
+certfile = /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_<%=properties.cassandra_server.cluster_name%>_CLIENT.cer.pem
 validate = <%=properties.cassandra_server.validate_ssl_TF%>
-userkey = /var/vcap/jobs/cassandra_server/config/certs/<%spec.ip%>_<%=properties.cassandra_server.cluster_name%>_CLIENT.key.pem
-usercert = /var/vcap/jobs/cassandra_server/config/certs/<%spec.ip%>_<%=properties.cassandra_server.cluster_name%>_CLIENT.cer.pem
+userkey = /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_<%=properties.cassandra_server.cluster_name%>_CLIENT.key.pem
+usercert = /var/vcap/jobs/cassandra_server/config/certs/<%=spec.ip%>_<%=properties.cassandra_server.cluster_name%>_CLIENT.cer.pem
 
 ;; Optional section, overrides default certfile in [ssl] section, if present
 ; [certfiles]

--- a/jobs/cassandra_server/templates/config/cqlshrc.erb
+++ b/jobs/cassandra_server/templates/config/cqlshrc.erb
@@ -1,0 +1,23 @@
+[authentication]
+username = cassandra
+password = <%=properties.cassandra_server.cass_KSP%>
+;;keyspace = 
+
+
+[connection]
+hostname = <%spec.ip%>
+port = 9042
+ssl = <%= properties.cassandra_server.cassandra_ssl_YN%>
+request_timeout = 1800
+
+[ssl]
+certfile = /var/vcap/jobs/cassandra_server/config/certs/<%spec.ip%>_<%=properties.cassandra_server.cluster_name%>_CLIENT.cer.pem
+validate = <%=properties.cassandra_server.validate_ssl_TF%>
+userkey = /var/vcap/jobs/cassandra_server/config/certs/<%spec.ip%>_<%=properties.cassandra_server.cluster_name%>_CLIENT.key.pem
+usercert = /var/vcap/jobs/cassandra_server/config/certs/<%spec.ip%>_<%=properties.cassandra_server.cluster_name%>_CLIENT.cer.pem
+
+;; Optional section, overrides default certfile in [ssl] section, if present
+; [certfiles]
+; 192.168.1.3 = ~/keys/cassandra01.cert
+; 192.168.1.4 = ~/keys/cassandra02.cert
+

--- a/jobs/cassandra_server/templates/helpers/ctl_setup.sh
+++ b/jobs/cassandra_server/templates/helpers/ctl_setup.sh
@@ -100,4 +100,18 @@ chmod +x  $JOB_DIR/tools/bin/cassandra-stress.sh
 #mkdir -p /var/vcap/store/restores
 #chmod 644 /var/vcap/store/restores
 mkdir -p $JOB_DIR/ssl
+chmod +x $JOB_DIR/config/certs/ssl_env.ctl
+chmod +x $JOB_DIR/config/certs/gen_keystore_client.sh
+
+if [[ -d ${JOB_DIR}/config/certs/newcerts ]]
+then
+ rm -rf $JOB_DIR/config/certs/newcerts/
+ mkdir -p $JOB_DIR/config/certs/newcerts
+else
+ mkdir -p $JOB_DIR/config/certs/newcerts
+fi
+
+chown vcap:vcap ${JOB_DIR}/config/certs/newcerts
+chown vcap:vcap ${JOB_DIR}/config/certs/
+
 mount -o remount ,exec,suid,nodev /tmp

--- a/jobs/cassandra_server/templates/helpers/ctl_setup.sh
+++ b/jobs/cassandra_server/templates/helpers/ctl_setup.sh
@@ -99,4 +99,5 @@ chmod +x  $JOB_DIR/tools/bin/cassandra-stress.sh
 #chmod 644 /var/vcap/store/backups
 #mkdir -p /var/vcap/store/restores
 #chmod 644 /var/vcap/store/restores
+mkdir -p $JOB_DIR/ssl
 mount -o remount ,exec,suid,nodev /tmp

--- a/jobs/cassandra_server/templates/ssl/cassandradb.ca.erb
+++ b/jobs/cassandra_server/templates/ssl/cassandradb.ca.erb
@@ -1,0 +1,1 @@
+<%= p("cassandra_server.cassDbCertificate.ca") -%>

--- a/jobs/cassandra_server/templates/ssl/cassandradb.pem.erb
+++ b/jobs/cassandra_server/templates/ssl/cassandradb.pem.erb
@@ -1,0 +1,2 @@
+<%= p("cassandra_server.cassDbCertificate.certificate") -%>
+<%= p("cassandra_server.cassDbCertificate.private_key") -%>

--- a/jobs/cassandra_server/templates/ssl2/cert
+++ b/jobs/cassandra_server/templates/ssl2/cert
@@ -1,0 +1,1 @@
+<%= p("cassandra_server.cert.certificate") %>

--- a/jobs/cassandra_server/templates/ssl2/cert_ca
+++ b/jobs/cassandra_server/templates/ssl2/cert_ca
@@ -1,0 +1,1 @@
+<%= p("cassandra_server.cert.ca") %>

--- a/jobs/cassandra_server/templates/ssl2/cert_private_key
+++ b/jobs/cassandra_server/templates/ssl2/cert_private_key
@@ -1,0 +1,1 @@
+<%= p("cassandra_server.cert.private_key") %>

--- a/jobs/cassandra_server/templates/ssl2/gen_ca_cert.conf
+++ b/jobs/cassandra_server/templates/ssl2/gen_ca_cert.conf
@@ -1,0 +1,35 @@
+[ ca ]
+default_ca =internalCA
+[ internalCA ]
+dir =/var/vcap/packages/cassandra_server/config/certs/
+certificate = $dir/ca.cert
+database = $dir/index.txt
+serial = $dir/serial
+new_certs_dir = $dir/newcerts
+private_key = $dir/node.key
+default_days = 365
+default_md = md5
+policy = CAuser_policy
+
+[ CAuser_policy ]
+stateOrProvinceName = optional
+countryName = supplied
+organizationName = supplied
+organizationalUnitName =optional
+commonName = supplied
+
+[ req ]
+distinguished_name = req_cassandra
+prompt = no
+default_bits = 2048
+default_keyfile = $dir/node.key
+
+[ req_cassandra ]
+C = FR
+ST = FR
+L = LYON
+O = Orange
+OU = TestCluster
+CN = `hostname -I`
+emailAddress = omer.missoum@orange.com
+

--- a/jobs/cassandra_server/templates/ssl2/gen_keystore_client.sh
+++ b/jobs/cassandra_server/templates/ssl2/gen_keystore_client.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+cd /var/vcap/jobs/cassandra_server/config/certs/
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin:.
+
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+export STOREPASS="<%=properties.cassandra_server.cass_KSP%>"
+export KEYPASS=$STOREPASS
+keytool -genkeypair -keyalg RSA -alias ${HOST_NAME} -keystore ${HOST_NAME}.jks -storepass $STOREPASS -keypass $KEYPASS -validity 3650 -keysize 2048 -dname "CN=${HOST_NAME}, OU=TestCluster, O=Orange, L=Lyon, S=FR, C=FR"
+
+keytool -keystore ${HOST_NAME}.jks -alias ${HOST_NAME} -certreq -file ${HOST_NAME}.csr -keypass $KEYPASS -storepass $STOREPASS
+exit 0

--- a/jobs/cassandra_server/templates/ssl2/ssl_env.ctl.erb
+++ b/jobs/cassandra_server/templates/ssl2/ssl_env.ctl.erb
@@ -5,15 +5,15 @@ set -u # report the usage of uninitialized variables.
 
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:$JAVA_HOME/bin
-export IN_OU_CERT_REQ=/var/vcap/jobs/cassandra_seed/config/certs/
-export CA_CERT_PEM=/var/vcap/jobs/casandra_seed/config/certs/cert
+export IN_OU_CERT_REQ=/var/vcap/jobs/cassandra_server/config/certs/
+export CA_CERT_PEM=/var/vcap/jobs/casandra_server/config/certs/cert
 
 ## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
 export HOST_NAME1=`hostname -I`
 export HOST_NAME=${HOST_NAME1//[[:space:]]}
 
-pushd /var/vcap/jobs/cassandra_seed/config/certs/
-exec chpst -u vcap:vcap /var/vcap/jobs/cassandra_seed/config/certs/./gen_keystore_client.sh 
+pushd /var/vcap/jobs/cassandra_server/config/certs/
+exec chpst -u vcap:vcap /var/vcap/jobs/cassandra_server/config/certs/./gen_keystore_client.sh 
 popd
 
 openssl ca -config ${IN_OU_CERT_REQ}/gen_ca_cert.conf -in ${IN_OU_CERT_REQ}/${HOST_NAME}.csr

--- a/jobs/cassandra_server/templates/ssl2/ssl_env.ctl.erb
+++ b/jobs/cassandra_server/templates/ssl2/ssl_env.ctl.erb
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin
+export IN_OU_CERT_REQ=/var/vcap/jobs/cassandra_seed/config/certs/
+export CA_CERT_PEM=/var/vcap/jobs/casandra_seed/config/certs/cert
+
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+
+pushd /var/vcap/jobs/cassandra_seed/config/certs/
+exec chpst -u vcap:vcap /var/vcap/jobs/cassandra_seed/config/certs/./gen_keystore_client.sh 
+popd
+
+openssl ca -config ${IN_OU_CERT_REQ}/gen_ca_cert.conf -in ${IN_OU_CERT_REQ}/${HOST_NAME}.csr
+
+exit 0

--- a/jobs/cassandra_server/templates/ssl3/gen_keystore_client.sh
+++ b/jobs/cassandra_server/templates/ssl3/gen_keystore_client.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+export KEY_STORE_PATH=/var/vcap/jobs/cassandra_server/config/certs/
+cd ${KEY_STORE_PATH}
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin:.
+
+export KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.keystore"
+export PKS_KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.pks12.keystore"
+export TRUST_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.truststore"
+export CLUSTER_NAME="<%=properties.cassandra_server.cluster_name%>"
+export CLUSTER_PUBLIC_CERT="$KEY_STORE_PATH/CLUSTER_${CLUSTER_NAME}_PUBLIC.cer"
+export CLIENT_PUBLIC_CERT="$KEY_STORE_PATH/CLIENT_${CLUSTER_NAME}_PUBLIC.cer"
+
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+export STOREPASS="<%=properties.cassandra_server.cass_KSP%>"
+export KEYPASS=$STOREPASS
+export PASSWORD=$KEYPASS
+
+
+### Cluster key setup.
+# Create the cluster key for cluster communication.
+keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLUSTER" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+-dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
+-validity 36500
+
+# Create the public key for the cluster which is used to identify nodes.
+keytool -export -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$KEY_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+# Import the identity of the cluster public cluster key into the trust store so that nodes can identify each other.
+keytool -import -v -trustcacerts -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+
+### Client key setup.
+# Create the client key for CQL.
+keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLIENT" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+-dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
+-validity 36500
+
+# Create the public key for the client to identify itself.
+keytool -export -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$KEY_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+# Import the identity of the client pub  key into the trust store so nodes can identify this client.
+keytool -importcert -v -trustcacerts -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+-storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
+
+
+
+keytool -importkeystore -srckeystore "$KEY_STORE" -destkeystore "$PKS_KEY_STORE" -deststoretype PKCS12 \
+-srcstorepass "$PASSWORD" -deststorepass "$PASSWORD"
+
+openssl pkcs12 -in "$PKS_KEY_STORE" -nokeys -out "${CLUSTER_NAME}_CLIENT.cer.pem" -passin pass:"$PASSWORD"
+openssl pkcs12 -in "$PKS_KEY_STORE" -nodes -nocerts -out "${CLUSTER_NAME}_CLIENT.key.pem" -passin pass:"$PASSWORD"
+
+
+exit 0
+

--- a/jobs/cassandra_server/templates/ssl3/gen_keystore_client.sh
+++ b/jobs/cassandra_server/templates/ssl3/gen_keystore_client.sh
@@ -7,15 +7,16 @@ cd ${KEY_STORE_PATH}
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:$JAVA_HOME/bin:.
 
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+
 export KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.keystore"
 export PKS_KEY_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.pks12.keystore"
 export TRUST_STORE="$KEY_STORE_PATH/${HOST_NAME}_cassandra.truststore"
 export CLUSTER_NAME="<%=properties.cassandra_server.cluster_name%>"
-export CLUSTER_PUBLIC_CERT="$KEY_STORE_PATH/CLUSTER_${CLUSTER_NAME}_PUBLIC.cer"
-export CLIENT_PUBLIC_CERT="$KEY_STORE_PATH/CLIENT_${CLUSTER_NAME}_PUBLIC.cer"
+export CLUSTER_PUBLIC_CERT="$KEY_STORE_PATH/${HOST_NAME}_CLUSTER_${CLUSTER_NAME}_PUBLIC.cer"
+export CLIENT_PUBLIC_CERT="$KEY_STORE_PATH/${HOST_NAME}_CLIENT_${CLUSTER_NAME}_PUBLIC.cer"
 
-export HOST_NAME1=`hostname -I`
-export HOST_NAME=${HOST_NAME1//[[:space:]]}
 export STOREPASS="<%=properties.cassandra_server.cass_KSP%>"
 export KEYPASS=$STOREPASS
 export PASSWORD=$KEYPASS
@@ -23,41 +24,37 @@ export PASSWORD=$KEYPASS
 
 ### Cluster key setup.
 # Create the cluster key for cluster communication.
-keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLUSTER" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+keytool -genkey -keyalg RSA -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
 -dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
 -validity 36500
 
 # Create the public key for the cluster which is used to identify nodes.
-keytool -export -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$KEY_STORE" \
+keytool -export -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$KEY_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
 
 # Import the identity of the cluster public cluster key into the trust store so that nodes can identify each other.
-keytool -import -v -trustcacerts -alias "${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+keytool -import -v -trustcacerts -alias "${HOST_NAME}_${CLUSTER_NAME}_CLUSTER" -file "$CLUSTER_PUBLIC_CERT" -keystore "$TRUST_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
 
 
 ### Client key setup.
 # Create the client key for CQL.
-keytool -genkey -keyalg RSA -alias "${CLUSTER_NAME}_CLIENT" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+keytool -genkey -keyalg RSA -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -keystore "$KEY_STORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
 -dname "CN=${HOST_NAME} $CLUSTER_NAME cluster, OU=Orange, O=Orange, L=Lyon, C=FR" \
 -validity 36500
 
 # Create the public key for the client to identify itself.
-keytool -export -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$KEY_STORE" \
+keytool -export -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$KEY_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
 
 # Import the identity of the client pub  key into the trust store so nodes can identify this client.
-keytool -importcert -v -trustcacerts -alias "${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$TRUST_STORE" \
+keytool -importcert -v -trustcacerts -alias "${HOST_NAME}_${CLUSTER_NAME}_CLIENT" -file "$CLIENT_PUBLIC_CERT" -keystore "$TRUST_STORE" \
 -storepass "$PASSWORD" -keypass "$PASSWORD" -noprompt
-
-
 
 keytool -importkeystore -srckeystore "$KEY_STORE" -destkeystore "$PKS_KEY_STORE" -deststoretype PKCS12 \
 -srcstorepass "$PASSWORD" -deststorepass "$PASSWORD"
 
-openssl pkcs12 -in "$PKS_KEY_STORE" -nokeys -out "${CLUSTER_NAME}_CLIENT.cer.pem" -passin pass:"$PASSWORD"
-openssl pkcs12 -in "$PKS_KEY_STORE" -nodes -nocerts -out "${CLUSTER_NAME}_CLIENT.key.pem" -passin pass:"$PASSWORD"
-
+openssl pkcs12 -in "$PKS_KEY_STORE" -nokeys -out "${HOST_NAME}_${CLUSTER_NAME}_CLIENT.cer.pem" -passin pass:"$PASSWORD"
+openssl pkcs12 -in "$PKS_KEY_STORE" -nodes -nocerts -out "${HOST_NAME}_${CLUSTER_NAME}_CLIENT.key.pem" -passin pass:"$PASSWORD"
 
 exit 0
-

--- a/jobs/cassandra_server/templates/ssl3/ssl_env.ctl.erb
+++ b/jobs/cassandra_server/templates/ssl3/ssl_env.ctl.erb
@@ -1,0 +1,22 @@
+#!/bin/bash
+#set -x
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+export JAVA_HOME=/var/vcap/packages/openjdk
+export PATH=$PATH:$JAVA_HOME/bin
+export IN_OU_CERT_REQ=/var/vcap/jobs/cassandra_server/config/certs/
+export CA_CERT_PEM=/var/vcap/jobs/cassandra_server/config/certs/cert
+
+## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
+export HOST_NAME1=`hostname -I`
+export HOST_NAME=${HOST_NAME1//[[:space:]]}
+
+pushd /var/vcap/jobs/cassandra_server/config/certs/
+exec chpst -u vcap:vcap /var/vcap/jobs/cassandra_server/config/certs/./gen_keystore_client.sh
+popd
+
+#openssl ca -config ${IN_OU_CERT_REQ}/gen_ca_cert.conf -in ${IN_OU_CERT_REQ}/${HOST_NAME}.csr
+
+exit 0
+

--- a/jobs/cassandra_server/templates/ssl3/ssl_env.ctl.erb
+++ b/jobs/cassandra_server/templates/ssl3/ssl_env.ctl.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 #set -x
-set -e # exit immediately if a simple command exits with a non-zero status.
+#set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
 
 export JAVA_HOME=/var/vcap/packages/openjdk


### PR DESCRIPTION
activation de connexions sécurisées (SSL/TLS) sur chaque noeud du cluster Cassandra pour un opérateur BOSH. En attendant une extension au broker ...
Le paramètrage SSL est débrayable via le manifest.yml   