### PR TITLE
Cleanups and refactorings

### DIFF
--- a/jobs/broker/spec
+++ b/jobs/broker/spec
@@ -1,12 +1,14 @@
 ---
 name: broker
+
 packages:
-- java-common
-- openjdk
-- cassandra-broker-pkg
+  - java-common
+  - openjdk
+  - cassandra-broker-pkg
+
 consumes:
-- name: seeds
-  type: cassandra_seeds
+  - name: seeds
+    type: cassandra
 
 templates:
   bin/ctl: bin/ctl
@@ -16,12 +18,10 @@ templates:
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
   config/application.yml.erb: config/application.yml
   config/logback.xml.erb: config/logback.xml
+
 properties:
   broker.user:
     description: cassandra service broker user
     default: broker
   broker.password:
     description: cassandra service broker password
-    
-  cassandra_seed.admin_password:
-    description: cassandra admin password  

--- a/jobs/broker/templates/config/application.yml.erb
+++ b/jobs/broker/templates/config/application.yml.erb
@@ -17,8 +17,8 @@ spring:
     show-banner: true
   data:
     cassandra:
-      password: <%= p('cassandra_seed.admin_password') %>
+      password: <%= link('seeds').p('cass_pwd') %>
       contact-points: <% link('seeds').instances.each do |instance| %><%= instance.address %>,<% end %>
       single-contact-points: <%= link('seeds').instances[0].address %>
       username: cassandra
-      port: 9042
+      port: <%= link('seeds').p('native_transport_port') %>

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -1,14 +1,20 @@
 ---
 name: cassandra
+
 packages:
   - cassandra
   - openjdk
+
 provides:
   - name: seeds
-    type: cassandra_seeds
+    type: cassandra
+    properties:
+      - cass_pwd
+      - native_transport_port
+
 consumes:
   - name: seeds
-    type: cassandra_seeds
+    type: cassandra
 
 templates:
   bin/cassandra_ctl: bin/cassandra_ctl

--- a/jobs/cassandra/templates/bin/cql-sh.sh
+++ b/jobs/cassandra/templates/bin/cql-sh.sh
@@ -1,29 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
 
 export LANG=en_US.UTF-8
 
-export CASSANDRA_BIN=/var/vcap/packages/cassandra/bin
-export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
-
-export JAVA_HOME=/var/vcap/packages/openjdk
-export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF
-
-## export CASSANDRA_CONF=/var/vcap/jobs/cassandra_server/conf
-
-export CLIENT_SSL=<%=properties.client_encryption_options.enabled%>
-
-if [[ ${CLIENT_SSL} == "true" ]]
-then 
- pushd /var/vcap/packages/cassandra/bin
- exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra/root/.cassandra/cqlshrc" "$@" --ssl
- popd
- exit 0
-else 
- pushd /var/vcap/packages/cassandra/bin
- exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/cqlsh --cqlshrc "/var/vcap/jobs/cassandra_seed/root/.cassandra/cqlshrc" "$@"
- popd
- exit 0
-fi
+exec chpst -u vcap:vcap \
+    env HOME=/home/vcap
+        /var/vcap/packages/cassandra/bin/cqlsh \
+            --cqlshrc /var/vcap/jobs/cassandra/root/.cassandra/cqlshrc \
+            "$@"

--- a/jobs/cassandra/templates/bin/node-tool.sh
+++ b/jobs/cassandra/templates/bin/node-tool.sh
@@ -1,24 +1,16 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
 
 export LANG=en_US.UTF-8
 
-export CASSANDRA_BIN=/var/vcap/packages/cassandra/bin
 export CASSANDRA_CONF=/var/vcap/jobs/cassandra/conf
 
 export JAVA_HOME=/var/vcap/packages/openjdk
-export PATH=$PATH:/var/vcap/packages/openjdk/bin
 
-pushd /var/vcap/packages/cassandra/bin
-if [ $# -eq 0 ];
-then
-        exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/nodetool status
-popd
-exit 0
+if [ $# -eq 0 ]; then
+	set status
 fi
 
-exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/nodetool "$@"
-popd
-exit 0
+exec chpst -u vcap:vcap env HOME=/home/vcap /var/vcap/packages/cassandra/bin/nodetool "$@"

--- a/jobs/cassandra/templates/config/cqlshrc.erb
+++ b/jobs/cassandra/templates/config/cqlshrc.erb
@@ -6,7 +6,7 @@ password = <%=properties.cass_pwd%>
 
 [connection]
 hostname = <%=spec.ip%>
-port = 9042
+port = <%= p('native_transport_port') %>
 ssl = <%=properties.cassandra_ssl_YN%>
 request_timeout = 1800
 

--- a/jobs/cassandra/templates/tools/bin/cassandra-stress.sh
+++ b/jobs/cassandra/templates/tools/bin/cassandra-stress.sh
@@ -1,25 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e # exit immediately if a simple command exits with a non-zero status.
 set -u # report the usage of uninitialized variables.
 
 export LANG=en_US.UTF-8
 
-export CASSANDRA_BIN=/var/vcap/packages/cassandra/bin
-export CASSANDRA_CONF=/var/vcap/jobs/cassandra/conf
-export CASSANDRA_TOOL=/var/vcap/packages/cassandra/tools/bin
-
 export JAVA_HOME=/var/vcap/packages/openjdk
-export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF:$CASSANDRA_TOOL
 
-pushd /var/vcap/packages/cassandra/tools/bin
-if [ $# -eq 0 ];
-then
-	exec chpst -u vcap:vcap /var/vcap/packages/cassandra/tools/bin/cassandra-stress write n=10
-popd
-exit 0
-fi
-
-exec chpst -u vcap:vcap /var/vcap/packages/cassandra/tools/bin/cassandra-stress "$@"
-popd
-exit 0
+exec chpst -u vcap:vcap env HOME=/home/vcap /var/vcap/packages/cassandra/tools/bin/cassandra-stress "$@"


### PR DESCRIPTION
In this PR, we fix and improve several things:

 - use the cassandra password as exposed (via link) by the `cassandra` jobs
 - same for cassandra TCP port
 - simplify several shell scripts
