### PR TITLE
Refactor SSL options

### DIFF
--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -266,12 +266,12 @@ properties:
   validate_ssl_TF:
     default: false
     description: cassandra ssl validate true or false
-  server_encryption_options.internode_encryption:
+  server_encryption.internode_encryption:
     default: false
     description: cassandra ssl entre noeuds true or false
-  client_encryption_options.enabled:
+  client_encryption.enabled:
     default: false
     description: cassandra SSL/TLS entre client et server true or false
-  client_encryption_options.require_client_auth:
+  client_encryption.require_client_auth:
     default: false
     description: cassandra ssl entre client et server et authentifi 

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -291,7 +291,9 @@ properties:
 
   client_encryption.enabled:
     default: false
-    description: cassandra SSL/TLS entre client et server true or false
+    description: |
+      Enables or disables client-to-node encryption.
   client_encryption.require_client_auth:
     default: false
-    description: cassandra ssl entre client et server et authentifi 
+    description: |
+      Enables or disables certificate authentication.

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -267,8 +267,27 @@ properties:
     default: false
     description: cassandra ssl validate true or false
   server_encryption.internode_encryption:
-    default: false
-    description: cassandra ssl entre noeuds true or false
+    default: none
+    description: |
+
+      Enables or disables encryption of inter-node communication using
+      the TLS_RSA_WITH_AES_128_CBC_SHA cipher suite for
+      authentication, key exchange, and encryption of data
+      transfers. Use the DHE/ECDHE ciphers, such as
+      TLS_DHE_RSA_WITH_AES_128_CBC_SHA if running in (Federal
+      Information Processing Standard) FIPS 140 compliant
+      mode. Available inter-node options:
+
+      * 'all': Encrypt all inter-node communications.
+
+      * 'none': No encryption.
+
+      * 'dc': Encrypt the traffic between the datacenters (server only).
+
+      * 'rack': Encrypt the traffic between the racks (server only).
+
+      See: <https://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html#configCassandra_yaml__ul_gbd_cns_1k>
+
   client_encryption.enabled:
     default: false
     description: cassandra SSL/TLS entre client et server true or false

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -254,9 +254,6 @@ properties:
     description:
   cass_pwd:
     default: cassandra
-  cassandra_ssl_YN:
-    default: N
-    description: use tls/ssl for authent and transactions 
   cassDbCertificate:
     default: "NOT INITIALIZED"
     description: use tls/ssl for authent and transactions 
@@ -274,7 +271,7 @@ properties:
     description: cassandra ssl entre noeuds true or false
   client_encryption_options.enabled:
     default: false
-    description: cassandra ssl entre client et server true or false
+    description: cassandra SSL/TLS entre client et server true or false
   client_encryption_options.require_client_auth:
     default: false
     description: cassandra ssl entre client et server et authentifi 

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -266,7 +266,8 @@ properties:
   validate_ssl_TF:
     default: false
     description: cassandra ssl validate true or false
-  server_encryption.internode_encryption:
+
+  internode_encryption_mode:
     default: none
     description: |
 

--- a/jobs/cassandra/templates/bin/creer_pem_cli_serv.sh
+++ b/jobs/cassandra/templates/bin/creer_pem_cli_serv.sh
@@ -7,7 +7,7 @@ pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
 export CASSANDRA_SSL=/var/vcap/jobs/cassandra/config/certs
 cd ${CASSANDRA_SSL}
 
-encryption=<%= p("client_encryption_options.enabled") %>
+encryption=<%= p("client_encryption.enabled") %>
 
 if [ "$encryption" == true ]; then
  /var/vcap/jobs/cassandra/config/certs/./ssl_env.ctl

--- a/jobs/cassandra/templates/bin/creer_pem_cli_serv.sh
+++ b/jobs/cassandra/templates/bin/creer_pem_cli_serv.sh
@@ -7,10 +7,9 @@ pushd `dirname $(readlink --canonicalize-existing $0)` >/dev/null
 export CASSANDRA_SSL=/var/vcap/jobs/cassandra/config/certs
 cd ${CASSANDRA_SSL}
 
-export SSL_YN=<%= p("cassandra_ssl_YN") %>
+encryption=<%= p("client_encryption_options.enabled") %>
 
-if ${SSL_YN} == "Y" 
-then
+if [ "$encryption" == true ]; then
  /var/vcap/jobs/cassandra/config/certs/./ssl_env.ctl
 fi
 

--- a/jobs/cassandra/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra/templates/config/cassandra.yaml.erb
@@ -77,7 +77,6 @@ server_encryption_options:
  protocol: TLS
 client_encryption_options:
  enabled: <%= p("client_encryption_options.enabled") %>
-##  optional: <%= p("client_encryption_options.optional") %>
  keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
  keystore_password: <%= p("cass_KSP") %>
  truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore

--- a/jobs/cassandra/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra/templates/config/cassandra.yaml.erb
@@ -69,17 +69,17 @@ request_scheduler: <%= p("request_scheduler") %>
 internode_compression: <%= p("internode_compression") %>
 inter_dc_tcp_nodelay: <%= p("inter_dc_tcp_nodelay") %>
 server_encryption_options:
- internode_encryption: <%= p("server_encryption_options.internode_encryption") %>
+ internode_encryption: <%= p("server_encryption.internode_encryption") %>
  keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
  keystore_password: <%= p("cass_KSP") %>
  truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
  truststore_password: <%= p("cass_KSP") %>
  protocol: TLS
 client_encryption_options:
- enabled: <%= p("client_encryption_options.enabled") %>
+ enabled: <%= p("client_encryption.enabled") %>
  keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
  keystore_password: <%= p("cass_KSP") %>
  truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
  truststore_password: <%= p("cass_KSP") %>
- require_client_auth: <%= p("client_encryption_options.require_client_auth") %>
+ require_client_auth: <%= p("client_encryption.require_client_auth") %>
  protocol: TLS

--- a/jobs/cassandra/templates/config/cqlshrc.erb
+++ b/jobs/cassandra/templates/config/cqlshrc.erb
@@ -7,7 +7,7 @@ password = <%= p("cass_pwd") %>
 [connection]
 hostname = <%=spec.ip%>
 port = <%= p('native_transport_port') %>
-ssl = <%= p("client_encryption_options.enabled") ? "Y" : "N" %>
+ssl = <%= p("client_encryption.enabled") ? "Y" : "N" %>
 request_timeout = 1800
 
 [ssl]

--- a/jobs/cassandra/templates/config/cqlshrc.erb
+++ b/jobs/cassandra/templates/config/cqlshrc.erb
@@ -7,7 +7,7 @@ password = <%= p("cass_pwd") %>
 [connection]
 hostname = <%=spec.ip%>
 port = <%= p('native_transport_port') %>
-ssl = <%= p("cassandra_ssl_YN") %>
+ssl = <%= p("client_encryption_options.enabled") ? "Y" : "N" %>
 request_timeout = 1800
 
 [ssl]

--- a/jobs/cassandra/templates/config/cqlshrc.erb
+++ b/jobs/cassandra/templates/config/cqlshrc.erb
@@ -7,7 +7,7 @@ password = <%= p("cass_pwd") %>
 [connection]
 hostname = <%=spec.ip%>
 port = <%= p('native_transport_port') %>
-ssl = <%= p("client_encryption.enabled") ? "Y" : "N" %>
+ssl = <%= p("client_encryption.enabled") %>
 request_timeout = 1800
 
 [ssl]


### PR DESCRIPTION
We have two similar options `cassandra_ssl_YN` and `server_encryption_options.internode_encryption`.

The point here is to merge those and rename that  to have a shorter name, yet still expressive.