### PR TITLE
Add the minimal wrapper scripts required by the Cassandra SHIELD plugin

### DIFF
--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -54,6 +54,8 @@ templates:
   bin/creer_pem_cli_serv.sh: bin/creer_pem_cli_serv.sh
   bin/post-start.sh: bin/post-start
   config/jmx_exporter.yml: conf/jmx_exporter.yml
+  bin/nodetool: bin/nodetool
+  bin/sstableloader: bin/sstableloader
   
 properties:
   cluster_name:

--- a/jobs/cassandra/templates/bin/nodetool
+++ b/jobs/cassandra/templates/bin/nodetool
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+export LANG=en_US.UTF-8
+
+export CASSANDRA_CONF=/var/vcap/jobs/cassandra/conf
+export JAVA_HOME=/var/vcap/packages/openjdk
+
+exec chpst -u vcap:vcap env HOME=/home/vcap /var/vcap/packages/cassandra/bin/nodetool "$@"

--- a/jobs/cassandra/templates/bin/sstableloader
+++ b/jobs/cassandra/templates/bin/sstableloader
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e # exit immediately if a simple command exits with a non-zero status.
+set -u # report the usage of uninitialized variables.
+
+export LANG=en_US.UTF-8
+
+export CASSANDRA_CONF=/var/vcap/jobs/cassandra/conf
+export JAVA_HOME=/var/vcap/packages/openjdk
+
+exec chpst -u vcap:vcap /var/vcap/packages/cassandra/bin/sstableloader "$@"


### PR DESCRIPTION
This is a requirement for the SHIELD backup plugin to work.

A subsequent PR is in the works in order to separate admin tools from server/daemon logic, as planned.