### PR TITLE
Document configuration properties

### DIFF
--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -62,86 +62,231 @@ properties:
       the benefit of improved security measures at runtime.
     default: false
   cluster_name:
-    default: testcluster
-    description: The name of the cluster. This setting prevents nodes in one logical cluster from joining another. 
+    description: |
+      The name of the cluster. This is mainly used to prevent machines in one
+      logical cluster from joining another.
+    default: testcluster # 'Test Cluster'
   num_tokens:
+    description: |
+      Defines the number of tokens randomly assigned to each node of the
+      instance group. The more tokens, relative to nodes of other instance
+      groups, the larger the proportion of data that this node will store.
+
+      When defining different instance groups for a single Cassandra cluster,
+      each with varying hardware capabilities, then the number of tokens
+      assigned to nodes of must be relative to their hardware capabilities.
     default: 256
-    description: Defines the number of tokens randomly assigned to this node on the ring when using virtual nodes vnodes.
   hinted_handoff_enabled:
+    description: |
+      Enables or disables hinted handoff. To enable per datacenter, add a list
+      of datacenters. For example: 'hinted_handoff_enabled: DC1,DC2'. A hint
+      indicates that the write needs to be replayed to an unavailable node.
+      Cassandra writes the hint to a hints file on the coordinator node.
+
+      See: <http://wiki.apache.org/cassandra/HintedHandoff>
+      See: <https://www.datastax.com/dev/blog/modern-hinted-handoff>
     default: true
-    description: Enable or disable hinted handoff To enable per data center add data center list For example hinted_handoff_enabled DC1DC2
+    example: DC1,DC2
   max_hint_window_in_ms:
-    default: 10800000
-    description: en ms donc 3 heures.Maximum amount of time that hints are generates hints for an unresponsive node.
+    description: |
+      Maximum amount of time (in milliseconds) during which Cassandra
+      generates hints for an unresponsive node. After this interval, Cassandra
+      does not generate any new hints for the node until it is back up and
+      responsive. If the node goes down again, Cassandra starts a new
+      interval.
+    default: 10800000 # 3 hours
   hinted_handoff_throttle_in_kb:
-    default: 1024 
-    description: taux de hint en Kbsec par thread. Il diminue proportionnellemnt au nombre de noeuds du cluster
+    description: |
+      Maximum amount of traffic per delivery thread in kilobytes per second.
+      This rate reduces proportionally to the number of nodes in the cluster.
+      For example, if there are two nodes in the cluster, each delivery thread
+      uses the maximum rate. If there are three, each node throttles to half
+      of the maximum, since the two nodes are expected to deliver hints
+      simultaneously.
+    default: 1024
   max_hints_delivery_threads:
+    description: |
+      Number of threads Cassandra uses to deliver hints. In multiple data-
+      center deployments, consider increasing this number because cross data-
+      center handoff is generally slower.
     default: 2
-    description: nombre de thread pour gerer les hints. A augmenter si cluster multi datacenter.
   authenticator:
+    description: |
+      The authentication backend. It implements IAuthenticator for identifying
+      users. Available authenticators:
+
+      - AllowAllAuthenticator:
+        Disables authentication; Cassandra performs no checks.
+
+      - PasswordAuthenticator:
+        Authenticates users with user names and hashed passwords stored in the
+        'system_auth.roles' table. Leaving the default replication factor of 1
+        set for the 'system_auth' keyspace results in denial of access to the
+        cluster if the single replica of the keyspace goes down.
     default: PasswordAuthenticator 
-    description: AllowAllAuthenticator c.a.d pas de controle sinon possible avec  PasswordAuthenticator.
   authorizer:
+    description: |
+      The authorization backend. It implements IAuthenticator to limit access
+      and provide permissions. Available authorizers:
+
+      - AllowAllAuthorizer:
+        Disables authorization: Cassandra allows any action to any user.
+
+      - CassandraAuthorizer:
+        Stores permissions in 'system_auth.permissions' table. Setting
+        'system_auth_keyspace_replication_factor' to 1 results in denial of
+        access to the cluster if the single replica of the keyspace goes down.
     default: CassandraAuthorizer
-    description: pour gerer les droits dans la bdd. Controle fin avec CassandraAuthorizer.
   permissions_validity_in_ms:
+    description: |
+      How many milliseconds permissions in cache remain valid. Depending on
+      the authorizer, such as 'CassandraAuthorizer', fetching permissions can
+      be resource intensive. This setting is disabled when set to 0 or when
+      'authorizer' is set to 'AllowAllAuthorizer'.
     default: 4000 
-    description: duree de validite des permissions stockees en cache.Se desactive en positionnant a 0 avec AllowAllAuthorizer.
   partitioner:
+    description: |
+      Sets the class that distributes rows (by partition key) across all nodes
+      in the cluster. Any IPartitioner may be used, including your own as long
+      as it is in the class path. For new clusters use the default
+      partitioner.
+
+      Cassandra provides the following partitioners for backwards compatibility:
+      - RandomPartitioner
+      - ByteOrderedPartitioner (deprecated)
+      - OrderPreservingPartitioner (deprecated)
     default: org.apache.cassandra.dht.Murmur3Partitioner 
-    description: par defaut Murmur3Partitioner. Existe aussi Randompartioner
   persistent_directory:
     default: /var/vcap/store/cassandra
     description: point racine de l arborescence Cassandra pour stocker tous les fichiers data, commit log et saved_cache
   disk_failure_policy:
+    description: |
+      Sets how Cassandra responds to disk failure. Recommend settings: 'stop'
+      or 'best_effort'. Valid values:
+
+      - die:
+        Shut down gossip and Thrift and kill the JVM for any file system
+        errors or single SSTable errors, so the node can be replaced.
+
+      - stop_paranoid:
+        Shut down gossip and Thrift even for single SSTable errors.
+
+      - stop:
+        Shut down gossip and Thrift, leaving the node effectively dead, but
+        available for inspection using JMX.
+
+      - best_effort:
+        Stop using the failed disk and respond to requests based on the
+        remaining available SSTables. This allows obsolete data at consistency
+        level of ONE.
+
+      - ignore:
+        Ignore fatal errors and lets the requests fail; all file system errors
+        are logged but otherwise ignored. Cassandra acts as in versions prior
+        to 1.2.
     default: stop 
-    description: que doit faire le noeud en cas de pb disque  die, stop, best_effort or ignore.
   key_cache_size_in_mb:
+    description: |
+      A global cache setting for the maximum size of the key cache in memory
+      (for all tables). If an empty string or a 'null' value is set, the cache
+      is set to the smaller of 5% of the available heap (when heap size is
+      above 2GB), or 100MB. To disable set to 0.
     default: 100
-    description: empty par defaut. Si vide alors Calculer comme min(5% Heap; 100Mb). Desactiver si = 0 .
   key_cache_save_period:
-    default: 14400
-    description: en secondes, soit 4 heures par defaut, pour la conservation des cles en cache sur disque
+    description: |
+      Duration in seconds that keys are kept in cache. Saved caches greatly
+      improve cold-start speeds and have relatively little effect on I/O.
+    default: 14400 # 4 hours
   row_cache_size_in_mb:
+    description: |
+      Maximum size of the row cache in memory. The row cache can save more
+      time than 'key_cache_size_in_mb', but it is space-intensive because it
+      contains the entire row. Use the row cache only for hot rows or static
+      rows. If you reduce the size, you may not get you hottest keys loaded on
+      start up.
     default: 0
-    description: 0 signifie desactive, c.a.d pas de stockages de ligne en cache.
   row_cache_save_period:
+    description: |
+      The number of seconds that rows are kept in cache. This setting has
+      limited use as described in 'row_cache_size_in_mb'.
     default: 0
-    description: 0 signifie desactive. Sinon duree en secondes pour la conservation sur disque du cache de lignes.
   commitlog_sync:
-    default: periodic 
-    description: periodic toutes les 10 sec flush cache fs (sync) du commit log vers disque. Acquitement instantannee. Sinon batch.
+    description: |
+
+      The method that Cassandra uses to acknowledge writes in milliseconds:
+
+      - periodic: (Default: 10000 milliseconds [10 seconds])
+        With 'commitlog_sync_period_in_ms', controls how often the commit log
+        is synchronized to disk. Periodic syncs are acknowledged immediately.
+
+      - batch: (Default: disabled)
+        Used with 'commitlog_sync_batch_window_in_ms' (Default: 2 ms), which
+        is the maximum length of time that queries may be batched together.
+    default: periodic
   commitlog_sync_period_in_ms:
     default: 2
     description: temps d attente d autres ecritures par cassandra avant de faire un sync. Utiliser si option batch activee. Acquittement retarde au sync.
   commitlog_segment_size_in_mb:
+    description: |
+      The size of an individual commitlog file segment. A commitlog segment
+      may be archived, deleted, or recycled after all its data has been
+      flushed to SSTables. This data can potentially include commitlog
+      segments from every table in the system. The default size is usually
+      suitable for most commitlog archiving, but if you want a finer
+      granularity, 8 or 16 MB is reasonable.
+
+      See also: <https://docs.datastax.com/en/cassandra/latest/cassandra/configuration/configLogArchive.html>
     default: 32
-    description: 32 Mb peut etre reduit a 8 ou 16 pour reduire le nombre de SSTables present dans un fichier.
   concurrent_reads:
+    description: |
+      Workloads with more data than can fit in memory encounter a bottleneck
+      in fetching data from disk during reads. Setting 'concurrent_reads' to
+      (16 × number_of_drives) allows operations to queue low enough in the
+      stack so that the OS and drives can reorder them. The default setting
+      applies to both logical volume managed (LVM) and RAID drives.
     default: 32
-    description: valeur recommandee 16 fois le nbr de drives; applicable aussi bien aux LVM qu aux disques RAIDs.
   concurrent_writes:
-    default: 32 
-    description: valeur recommandee 8 fois le nbr de CPU
+    description: |
+      Writes in Cassandra are rarely I/O bound, so the ideal number of
+      concurrent writes depends on the number of CPU cores on the node. The
+      recommended value is 8 × number_of_cpu_cores.
+    default: 32
   file_cache_size_in_mb:
+    description: |
+      Total memory to use for SSTable-reading buffers. Defaults to the smaller
+      of 1/4 of heap (when heap is less than 2GB) or 512MB.
     default: 512
-    description: defaut = min 14 HEap; 512. C est la memoire totale utilisable pour la lecture des SST.
   memtable_flush_writers:
+    description: |
+      The number of memtable flush writer threads. These threads are blocked
+      by disk I/O, and each one holds a memtable in memory while blocked. If
+      your data directories are backed by SSDs, increase this setting to the
+      number of cores.
+
+      (Default: Smaller of number of disks or number of cores with a minimum
+      of 2 and a maximum of 8)
     default: 1
-    description: defaut = min('Nbr disks|nbr CPUs';2|8)
   trickle_fsync:
+    description: |
+      When set to 'true', causes fsync to force the operating system to flush
+      the dirty buffers at the set interval 'trickle_fsync_interval_in_kb'.
+      Enable this parameter to prevent sudden dirty buffer flushing from
+      impacting read latencies. Recommended for use with SSDs, but not with
+      HDDs.
     default: false
-    description:
   trickle_fsync_interval_in_kb:
-    default: 10240
-    description:
+    description: |
+      The size of the fsync in kilobytes.
+    default: 10240 # 10MB
   storage_port:
+    description: |
+      The port for inter-node communication.
     default: 7000
-    description:
   ssl_storage_port:
+    description: |
+      The SSL port for encrypted communication. Unused when
+      'internode_encryption_mode' is set to 'none'.
     default: 7001
-    description:
   start_native_transport:
     default: true
     description:

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -54,7 +54,7 @@ templates:
   config/jmx_exporter.yml: conf/jmx_exporter.yml
   bin/nodetool: bin/nodetool
   bin/sstableloader: bin/sstableloader
-  
+
 properties:
   bpm.enabled:
     description: |
@@ -123,7 +123,7 @@ properties:
         'system_auth.roles' table. Leaving the default replication factor of 1
         set for the 'system_auth' keyspace results in denial of access to the
         cluster if the single replica of the keyspace goes down.
-    default: PasswordAuthenticator 
+    default: PasswordAuthenticator
   authorizer:
     description: |
       The authorization backend. It implements IAuthenticator to limit access
@@ -143,7 +143,7 @@ properties:
       the authorizer, such as 'CassandraAuthorizer', fetching permissions can
       be resource intensive. This setting is disabled when set to 0 or when
       'authorizer' is set to 'AllowAllAuthorizer'.
-    default: 4000 
+    default: 4000
   partitioner:
     description: |
       Sets the class that distributes rows (by partition key) across all nodes
@@ -155,7 +155,7 @@ properties:
       - RandomPartitioner
       - ByteOrderedPartitioner (deprecated)
       - OrderPreservingPartitioner (deprecated)
-    default: org.apache.cassandra.dht.Murmur3Partitioner 
+    default: org.apache.cassandra.dht.Murmur3Partitioner
   persistent_directory:
     default: /var/vcap/store/cassandra
     description: point racine de l arborescence Cassandra pour stocker tous les fichiers data, commit log et saved_cache
@@ -184,7 +184,7 @@ properties:
         Ignore fatal errors and lets the requests fail; all file system errors
         are logged but otherwise ignored. Cassandra acts as in versions prior
         to 1.2.
-    default: stop 
+    default: stop
   key_cache_size_in_mb:
     description: |
       A global cache setting for the maximum size of the key cache in memory
@@ -288,132 +288,439 @@ properties:
       'internode_encryption_mode' is set to 'none'.
     default: 7001
   start_native_transport:
+    description: |
+      Enables or disables the native transport server. This server uses the
+      same address as the 'rpc_address', but the port it uses is different
+      from 'rpc_port'. See 'native_transport_port'.
     default: true
-    description:
   native_transport_port:
+    description: |
+      The port where the CQL native transport listens for clients.
     default: 9042
-    description:
   native_transport_max_threads:
+    description: |
+      The maximum number of thread handling requests. Similar to
+      'rpc_max_threads', but this property differs as follows:
+
+      - The default for 'native_transport_max_threads' is 128; the default for
+        'rpc_max_threads' is 2048.
+
+      - There is no corresponding 'native_transport_min_threads'.
+
+      - Cassandra stops idle native transport threads after 30 seconds.
     default: 128
-    description:
   native_transport_max_frame_size_in_mb:
+    description: |
+      The maximum allowed size of a frame. Frame (requests) larger than this
+      are rejected as invalid.
+
+      If you're changing this parameter, you may want to adjust
+      'max_value_size_in_mb' accordingly. This should be positive and less than
+      2048.
     default: 256
-    description:
   start_rpc:
+    description: |
+      Enables or disables the Thrift RPC server.
     default: true
-    description:
-  rpc_address:
-    default: localhost
-    description:
   rpc_port:
+    description: |
+      Thrift port for client connections.
     default: 9160
-    description:
   rpc_keepalive:
+    description: |
+      Enables or disables keepalive on client connections (RPC or native).
     default: true
-    description:
   rpc_server_type:
+    description: |
+      Cassandra provides three options for the RPC server. 'sync' and 'hsha'
+      performance is about the same, but 'hsha' uses less memory.
+
+      - 'sync': (Default: one thread per Thrift connection.)
+        For a very large number of clients, memory is the limiting factor. On
+        a 64-bit JVM, 180KB is the minimum stack size per thread and
+        corresponds to your use of virtual memory. Physical memory may be
+        limited depending on use of stack space.
+
+      - 'hsha':
+        Half synchronous, half asynchronous. All Thrift clients are handled
+        asynchronously using a small number of threads that does not vary with
+        the number of clients. This mechanism scales well to many clients. The
+        RPC requests are synchronous (one thread per active request).
+
+        Note: If you select this option, you must change the default value
+        (unlimited) of 'rpc_max_threads'.
+
+      - Your own RPC server
+        You must provide a fully-qualified class name of an
+        'o.a.c.t.TServerFactory' that can create a server instance.
     default: sync
-    description:
   rpc_min_threads:
+    description: |
+      The minimum thread pool size for remote procedure calls.
     default: 16
-    description:
   rpc_max_threads:
+    description: |
+      Regardless of your choice of RPC server (See 'rpc_server_type'),
+      'rpc_max_threads' dictates the maximum number of concurrent requests in
+      the RPC thread pool. If you are using the parameter 'sync' (see
+      'rpc_server_type') it also dictates the number of clients that can be
+      connected. A high number of client connections could cause excessive
+      memory usage for the thread stack. Connection pooling on the client side
+      is highly recommended. Setting a 'rpc_max_threads' acts as a safeguard
+      against misbehaving clients. If the number of threads reaches the
+      maximum, Cassandra blocks additional connections until a client
+      disconnects.
     default: 2048
-    description:
   thrift_framed_transport_size_in_mb:
+    description: |
+      Frame size (maximum field length) for Thrift. The frame is the row or
+      part of the row that the application is inserting.
     default: 15
-    description:
   incremental_backups:
+    description: |
+      Backs up data updated since the last snapshot was taken. When enabled,
+      Cassandra creates a hard link to each SSTable flushed or streamed
+      locally in a backups subdirectory of the keyspace data. Removing these
+      links is the operator's responsibility.
+
+      See also: <https://docs.datastax.com/en/cassandra/latest/cassandra/operations/opsBackupIncremental.html>
     default: false
-    description:
   snapshot_before_compaction:
+    description: |
+      Enables or disables taking a snapshot before each compaction. A snapshot
+      is useful to back up data when there is a data format change. Be careful
+      using this option: Cassandra does not clean up older snapshots
+      automatically.
     default: false
-    description:
   auto_snapshot:
+    description: |
+      Whether Cassandra takes a snapshot of the data before truncating a
+      keyspace or dropping a table. To prevent data loss, DataStax strongly
+      advises using the default setting. If you set 'auto_snapshot' to
+      'false', data loss occurs on truncation or drop.
     default: true
-    description:
-  tombstone_warn_threshold:
-    default: 1000
-    description:
-  tombstone_failure_threshold:
-    default: 100000
-    description:
   column_index_size_in_kb:
+    description: |
+      Granularity of the index of rows within a partition. For huge rows,
+      decrease this setting to improve seek time. If you use key cache, be
+      careful not to make this setting too large because key cache will be
+      overwhelmed. If you're unsure of the size of the rows, it's best to use
+      the default setting.
     default: 64
-    description:
   concurrent_compactors:
+    description: |
+      The number of concurrent compaction processes allowed to run
+      simultaneously on a node, not including validation compactions for anti-
+      entropy repair. Simultaneous compactions help preserve read performance
+      in a mixed read-write workload by limiting the number of small SSTables
+      that accumulate during a single long-running compaction. If your data
+      directories are backed by SSDs, increase this value to the number of
+      cores. If compaction running too slowly or too fast, adjust
+      'compaction_throughput_mb_per_sec' first.
+
+      Note: Increasing concurrent compactors leads to more use of available
+      disk space for compaction, because concurrent compactions happen in
+      parallel, especially for STCS. Ensure that adequate disk space is
+      available before increasing this configuration.
     default: 4
-    description:
   read_request_timeout_in_ms:
-    default: 5000
-    description:
+    description: |
+      The number of milliseconds that the coordinator waits for read
+      operations to complete before timing it out.
+    default: 5000 # 5 seconds
   range_request_timeout_in_ms:
+    description: |
+      The number of milliseconds that the coordinator waits for sequential or
+      index scans to complete before timing it out.
     default: 10000
-    description:
   write_request_timeout_in_ms:
+    description: |
+      The number of milliseconds that the coordinator waits for a write
+      operations to complete before timing it out for requests with at least
+      one node in the local datacenter.
     default: 2000
-    description:
   cas_contention_timeout_in_ms:
+    description: |
+      The number of milliseconds during which the coordinator continues to
+      retry a CAS (compare and set) operation that contends with other
+      proposals for the same row. If the coordinator cannot complete the
+      operation within this timespan, it aborts the operation.
     default: 1000
-    description:
   truncate_request_timeout_in_ms:
+    description: |
+      The number of milliseconds that the coordinator waits for a truncate
+      (the removal of all data from a table) to complete before timing it out.
+      The long default value allows Cassandra to take a snapshot before
+      removing the data. If 'auto_snapshot' is disabled (not recommended), you
+      can reduce this time.
     default: 60000
-    description:
   request_timeout_in_ms:
+    description: |
+      The default timeout value for other miscellaneous operations.
     default: 10000
-    description:
   cross_node_timeout:
+    description: |
+      Enables or disables operation timeout information exchange between nodes
+      (to accurately measure request timeouts). If this property is disabled,
+      the replica assumes any requests are forwarded to it instantly by the
+      coordinator. During overload conditions this means extra time is
+      required for processing already-timed-out requests.
+
+        CAUTION:
+        Before enabling this property make sure NTP (network time protocol) is
+        installed and the times are synchronized among the nodes.
     default: false
-    description:
   phi_convict_threshold:
+    description: |
+      Adjusts the sensitivity of the failure detector on an exponential scale.
+      Generally this setting does not need adjusting.
     default: 8
-    description:
   endpoint_snitch:
+    description: |
+      Set to a class that implements the IEndpointSnitch interface. Cassandra
+      uses the snitch to locate nodes and route requests.
+
+      - 'SimpleSnitch'
+        Use for single-datacenter deployment or single-zone deployment in
+        public clouds. Does not recognize datacenter or rack information.
+        Treats strategy order as proximity, which can improve cache locality
+        when you disable read repair.
+
+      - 'GossipingPropertyFileSnitch'
+        Recommended for production. Reads rack and datacenter for the local
+        node in 'cassandra-rackdc.properties' file and propagates these values
+        to other nodes via gossip. For migration from the PropertyFileSnitch,
+        uses the 'cassandra-topology.properties' file if it is present.
+
+      - 'PropertyFileSnitch'
+        Determines proximity by rack and datacenter, which are explicitly
+        configured in 'cassandra-topology.properties' file.
+
+      - 'Ec2Snitch'
+        For EC2 deployments in a single region. Loads region and availability
+        zone information from the Amazon EC2 API. The region is treated as the
+        datacenter and the availability zone as the rack and uses only private
+        IP addresses. For this reason, it does not work across multiple
+        regions.
+
+      - 'Ec2MultiRegionSnitch'
+        Uses the public IP as the broadcast_address to allow cross-region
+        connectivity. This means you must also set seed addresses to the
+        public IP and open the 'storage_port' or 'ssl_storage_port' on the
+        public IP firewall. For intra-region traffic, Cassandra switches to
+        the private IP after establishing a connection.
+
+      - 'RackInferringSnitch'
+        Proximity is determined by rack and datacenter, which are assumed to
+        correspond to the 3rd and 2nd octet of each node's IP address,
+        respectively. Best used as an example for writing a custom snitch
+        class (unless this happens to match your deployment conventions).
+
+      - 'GoogleCloudSnitch'
+        Use for Cassandra deployments on Google Cloud Platform across one or
+        more regions. The region is treated as a datacenter and the
+        availability zones are treated as racks within the datacenter. All
+        communication occurs over private IP addresses within the same logical
+        network.
+
+      - 'CloudstackSnitch'
+        Use this snitch for Apache Cloudstack environments.
     default: PropertyFileSnitch
-    description:
-  dynamic_snitch_update_interval_in_ms:
-    default: 100
-    description:
-  dynamic_snitch_reset_interval_in_ms:
-    default: 600000
-    description:
-  dynamic_snitch_badness_threshold:
-    default: 0.1
-    description:
-  request_scheduler:
-    default: org.apache.cassandra.scheduler.NoScheduler
-    description:
-  request_scheduler_id:
-    default: 
-    description:
-  internode_compression:
-    default: none
-    description:
-  inter_dc_tcp_nodelay:
-    default: true
-    description:
-  max_heap_size:
-    default: 8G
-    description:
-  heap_newsize:
-    default: 1G
-    description:
   topology:
-    description:
-  cass_pwd:
-    default: cassandra
+    description: |
+      The topology (in Java Properties file syntax) to be injected in the
+      'cassandra-topology.properties' file. Directives are expressed as an
+      array, the elements of which will be joined with newlines ('\n'). Thus,
+      each array elements can be made of one or many Java Properties,
+      depending on what fits best for your use-case.
+
+      The template 'cassandra-topology.properties' file includes a
+      'default=DC1:RAC1' directive that applies to all unknown nodes.
+    default: ''
+    example:
+    - |
+      192.168.1.100=DC1:RAC1
+      192.168.2.200=DC2:RAC2
+    - |
+      10.0.0.11=DC1:RAC1
+      10.0.0.12=DC1:RAC2
+  dynamic_snitch_update_interval_in_ms:
+    description: |
+      The number of milliseconds between Cassandra's calculation of node
+      scores. Because score calculation is CPU intensive, be careful when
+      reducing this interval.
+    default: 100 # 0.1 second
+  dynamic_snitch_reset_interval_in_ms:
+    description: |
+      Time interval after which Cassandra resets all node scores. This allows
+      a bad node to recover.
+    default: 600000 # 10 minutes
+  dynamic_snitch_badness_threshold:
+    description: |
+      The performance threshold for dynamically routing client requests away
+      from a poorly performing node. Specifically, it controls how much worse
+      a poorly performing node has to be before the dynamic snitch prefers
+      other replicas over it. A value of 0.2 means Cassandra continues to
+      prefer the static snitch values until the node response time is 20%
+      worse than the best performing node. Until the threshold is reached,
+      incoming requests are statically routed to the closest replica (as
+      determined by the snitch). A value greater than zero for this parameter,
+      with a value of less than 1.0 for 'read_repair_chance', maximizes cache
+      capacity across the nodes.
+    default: 0.1
+  request_scheduler:
+    description: |
+      The scheduler to handle incoming client requests according to a defined
+      policy. This scheduler is useful for throttling client requests in
+      single clusters containing multiple keyspaces. This parameter is
+      specifically for requests from the client and does not affect inter-node
+      communication. Valid values:
+
+      - 'org.apache.cassandra.scheduler.NoScheduler'
+        Cassandra does no scheduling.
+
+      - 'org.apache.cassandra.scheduler.RoundRobinScheduler'
+        Cassandra uses a round robin of client requests to a node with a
+        separate queue for each 'request_scheduler_id' property. (Currently
+        'request_scheduler_id' can only be 'keyspace' as the scope of the
+        scheduler's activity.)
+
+      - Cassandra uses a Java class that implements the 'RequestScheduler'
+        interface.
+    default: org.apache.cassandra.scheduler.NoScheduler
+
+  internode_encryption_mode:
+    description: |
+      Enables or disables encryption of inter-node communication using the
+      'TLS_RSA_WITH_AES_128_CBC_SHA' cipher suite for authentication, key
+      exchange, and encryption of data transfers. Use the DHE/ECDHE ciphers,
+      such as 'TLS_DHE_RSA_WITH_AES_128_CBC_SHA' if running in (Federal
+      Information Processing Standard) FIPS 140 compliant mode. Available
+      inter-node options:
+
+      - 'all': Encrypt all inter-node communications.
+      - 'none': No encryption.
+      - 'dc': Encrypt the traffic between the datacenters (server only).
+      - 'rack': Encrypt the traffic between the racks (server only).
+
+      See: <https://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html#configCassandra_yaml__ul_gbd_cns_1k>
+    default: none
+  client_encryption.enabled:
+    default: false
+    description: |
+      Enables or disables client-to-node encryption.
+  client_encryption.require_client_auth:
+    default: false
+    description: |
+      Enables or disables certificate authentication.
+  cass_KSP:
+    description: |
+      Password for the keystore that is used to to store server and client
+      encryption certificates and keys.
   cassDbCertificate:
+    type: certificate
+    description: |
+      use tls/ssl for authent and transactions.
+
+      Structured certificate as can be provided by CredHub.
+
+      Injected in:
+      - .ca: ssl/cassandradb.ca.erb (deprecated)
+      - .certificate and .private_key: cassandradb.pem.erb (deprecated)
+
     default: "NOT INITIALIZED"
-    description: use tls/ssl for authent and transactions 
   cert:
     type: certificate
-    description: cluster certificate
-  cass_KSP:
-    default: 
-    description: cassandra ssl keystore passwd
+    description: |
+      Cluster certificate.
+    example:
+      ca: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      cetificate: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      provate_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        ...
+        -----END RSA PRIVATE KEY-----
+
+  internode_compression:
+    description: |
+      Controls whether traffic between nodes is compressed. Valid values:
+
+      - 'all'
+        Compresses all traffic.
+
+      - 'dc'
+        Compresses traffic between datacenters only.
+
+      - 'none'
+        No compression.
+    default: none
+  inter_dc_tcp_nodelay:
+    description: |
+      Enable this property or 'disable tcp_nodelay' for inter-datacenter
+      communication. If this property is disabled, the network sends larger,
+      but fewer, network packets. This reduces overhead from the TCP protocol
+      itself. However, disabling 'inter_dc_tcp_nodelay' may increase latency
+      by blocking cross data-center responses.
+    default: true
+
+  tombstone_warn_threshold:
+    description: |
+      Cassandra issues a warning if a query scans more than this number of
+      tombstones.
+    default: 1000
+  tombstone_failure_threshold:
+    description: |
+      Cassandra aborts a query if it scans more than this number of
+      tombstones.
+    default: 100000
+
+  max_heap_size:
+    description: |
+      The total amount of memory dedicated to the Java heap.
+
+      The default max heap size is based on the following calculation:
+
+        max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
+
+      Which can be described by this algorithm:
+        1. calculate 1/2 ram and cap to 1024MB
+        2. calculate 1/4 ram and cap to 8192MB
+        3. pick the max
+    default: 8G
+  heap_newsize:
+    description: |
+      Size of the young generation.
+
+      The default young generation size is computed as folows:
+
+        min(max_sensible_per_modern_cpu_core * num_cores, 1/4 * heap size)
+
+      Where 'max_sensible_per_modern_cpu_core' is 100 MB, which assumes a
+      modern 8-core+ machine for decent pause times. If in doubt, and if you
+      do not particularly want to tweak, go with 100 MB per physical CPU core.
+
+      On Linux, the 'num_cores' value is taken from the 'processor:' property
+      as found in '/proc/cpuinfo'. Be careful that in BOSH-Lite (using Garden
+      RunC), this may not be accurate.
+
+      The main trade-off for the young generation is that the larger it is,
+      the longer GC pause times will be. The shorter it is, the more expensive
+      GC will be (usually).
+    default: 1G
+  cass_pwd:
+    default: cassandra
   validate_ssl_TF:
+    description: |
+      When validate is enabled, the cqlsh clients will verify that the
+      certificate is trusted. The host in the certificate is compared to the
+      host of the machine to which it is connected.
     default: false
-    description: cassandra ssl validate true or false
 
   system_auth_keyspace_replication_factor:
     description: |
@@ -433,40 +740,12 @@ properties:
       In Bosh-Lite, you need to set this to 'false', as the 'swapoff'
       command cannot be invoked within Garden containers.
     default: true
-  internode_encryption_mode:
-    default: none
-    description: |
 
-      Enables or disables encryption of inter-node communication using
-      the TLS_RSA_WITH_AES_128_CBC_SHA cipher suite for
-      authentication, key exchange, and encryption of data
-      transfers. Use the DHE/ECDHE ciphers, such as
-      TLS_DHE_RSA_WITH_AES_128_CBC_SHA if running in (Federal
-      Information Processing Standard) FIPS 140 compliant
-      mode. Available inter-node options:
-
-      * 'all': Encrypt all inter-node communications.
-
-      * 'none': No encryption.
-
-      * 'dc': Encrypt the traffic between the datacenters (server only).
-
-      * 'rack': Encrypt the traffic between the racks (server only).
-
-      See: <https://docs.datastax.com/en/cassandra/3.0/cassandra/configuration/configCassandra_yaml.html#configCassandra_yaml__ul_gbd_cns_1k>
-
-  client_encryption.enabled:
-    default: false
-    description: |
-      Enables or disables client-to-node encryption.
-  client_encryption.require_client_auth:
-    default: false
-    description: |
-      Enables or disables certificate authentication.
   jmx_exporter_enabled:
+    description: |
+      Scrape and expose mBeans of a JMX target.
     default: true
-    description: scrape and expose mBeans of a JMX target
   jmx_exporter_port:
+    description: |
+      Port on which to expose metrics and web interface.
     default: 9001
-    description: Port on which to expose metrics and web interface
-

--- a/jobs/cassandra/templates/bin/post-start.sh
+++ b/jobs/cassandra/templates/bin/post-start.sh
@@ -70,6 +70,10 @@ fi
 
 
 log_err "INFO: setting replication strategy for cassandra password"
+# Note: should we support multiple datacenters one day, then we should set the
+# replication class to 'NetworkTopologyStrategy' here instead of 'SimpleStrategy'.
+# See: <https://docs.datastax.com/en/cassandra/latest/cassandra/configuration/configCassandra_yaml.html#configCassandra_yaml__authenticator>
+# See: <https://docs.datastax.com/en/cassandra/latest/cassandra/configuration/configCassandra_yaml.html#configCassandra_yaml__authorizer>
 $CASSANDRA_BIN/cqlsh --cqlshrc "$job_dir/root/.cassandra/cqlshrc" \
      -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '<%= p('system_auth_keyspace_replication_factor') %>'}  AND durable_writes = true"
 

--- a/jobs/cassandra/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra/templates/config/cassandra.yaml.erb
@@ -1,38 +1,1237 @@
+# Cassandra storage config YAML
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
 cluster_name: <%= p("cluster_name") %>
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting on the node's initial start,
+# on subsequent starts, this setting will apply even if initial token is set.
+#
+# If you already have a cluster with 1 token per node, and wish to migrate to 
+# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
 num_tokens: <%= p("num_tokens") %>
+
+# Triggers automatic allocation of num_tokens tokens for this node. The allocation
+# algorithm attempts to choose tokens in a way that optimizes replicated load over
+# the nodes in the datacenter for the replication strategy used by the specified
+# keyspace.
+#
+# The load assigned to each node will be close to proportional to its number of
+# vnodes.
+#
+# Only supported with the Murmur3Partitioner.
+# allocate_tokens_for_keyspace: KEYSPACE
+
+# initial_token allows you to specify tokens manually.  While you can use it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a 
+# comma-separated list -- it's primarily used when adding nodes to legacy clusters 
+# that do not have vnodes enabled.
+# initial_token:
+
+# See http://wiki.apache.org/cassandra/HintedHandoff
+# May either be "true" or "false" to enable globally
 hinted_handoff_enabled: <%= p("hinted_handoff_enabled") %>
+
+# When hinted_handoff_enabled is true, a black list of data centers that will not
+# perform hinted handoff
+# hinted_handoff_disabled_datacenters:
+#    - DC1
+#    - DC2
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
 max_hint_window_in_ms: <%= p("max_hint_window_in_ms") %>
+
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
 hinted_handoff_throttle_in_kb: <%= p("hinted_handoff_throttle_in_kb") %>
+
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
 max_hints_delivery_threads: <%= p("max_hints_delivery_threads") %>
+
+# Directory where Cassandra should store hints.
+# If not set, the default directory is $CASSANDRA_HOME/data/hints.
+hints_directory: <%= p("persistent_directory") %>/<%= p("cluster_name") %>/hint
+
+# How often hints should be flushed from the internal buffers to disk.
+# Will *not* trigger fsync.
+hints_flush_period_in_ms: 10000
+
+# Maximum size for a single hints file, in megabytes.
+max_hints_file_size_in_mb: 128
+
+# Compression to apply to the hint files. If omitted, hints files
+# will be written uncompressed. LZ4, Snappy, and Deflate compressors
+# are supported.
+#hints_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: 1024
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.roles table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+#   If using PasswordAuthenticator, CassandraRoleManager must also be used (see below)
 authenticator: <%= p("authenticator") %>
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.role_permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
 authorizer: <%= p("authorizer") %>
+
+# Part of the Authentication & Authorization backend, implementing IRoleManager; used
+# to maintain grants and memberships between roles.
+# Out of the box, Cassandra provides org.apache.cassandra.auth.CassandraRoleManager,
+# which stores role information in the system_auth keyspace. Most functions of the
+# IRoleManager require an authenticated login, so unless the configured IAuthenticator
+# actually implements authentication, most of this functionality will be unavailable.
+#
+# - CassandraRoleManager stores role data in the system_auth keyspace. Please
+#   increase system_auth keyspace replication factor if you use this role manager.
+role_manager: CassandraRoleManager
+
+# Validity period for roles cache (fetching granted roles can be an expensive
+# operation depending on the role manager, CassandraRoleManager is one example)
+# Granted roles are cached for authenticated sessions in AuthenticatedUser and
+# after the period specified here, become eligible for (async) reload.
+# Defaults to 2000, set to 0 to disable caching entirely.
+# Will be disabled automatically for AllowAllAuthenticator.
+roles_validity_in_ms: 2000
+
+# Refresh interval for roles cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If roles_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as roles_validity_in_ms.
+# roles_update_interval_in_ms: 2000
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
 permissions_validity_in_ms: <%= p("permissions_validity_in_ms") %>
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+
+# Validity period for credentials cache. This cache is tightly coupled to
+# the provided PasswordAuthenticator implementation of IAuthenticator. If
+# another IAuthenticator implementation is configured, this cache will not
+# be automatically used and so the following settings will have no effect.
+# Please note, credentials are cached in their encrypted form, so while
+# activating this cache may reduce the number of queries made to the
+# underlying table, it may not  bring a significant reduction in the
+# latency of individual authentication attempts.
+# Defaults to 2000, set to 0 to disable credentials caching.
+credentials_validity_in_ms: 2000
+
+# Refresh interval for credentials cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If credentials_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as credentials_validity_in_ms.
+# credentials_update_interval_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Besides Murmur3Partitioner, partitioners included for backwards
+# compatibility include RandomPartitioner, ByteOrderedPartitioner, and
+# OrderPreservingPartitioner.
+#
 partitioner: <%= p("partitioner") %>
+
+# Directories where Cassandra should store data on disk.  Cassandra
+# will spread data evenly across them, subject to the granularity of
+# the configured compaction strategy.
+# If not set, the default directory is $CASSANDRA_HOME/data/data.
 data_file_directories:
     - <%= p("persistent_directory") %>/<%= p("cluster_name") %>/data
-hints_directory: <%= p("persistent_directory") %>/<%= p("cluster_name") %>/hint
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
 commitlog_directory: <%= p("persistent_directory") %>/<%= p("cluster_name") %>/commitlog
+
+# Enable / disable CDC functionality on a per-node basis. This modifies the logic used
+# for write path allocation rejection (standard: never reject. cdc: reject Mutation
+# containing a CDC-enabled table if at space limit in cdc_raw_directory).
+cdc_enabled: false
+
+# CommitLogSegments are moved to this directory on flush if cdc_enabled: true and the
+# segment contains mutations for a CDC-enabled table. This should be placed on a
+# separate spindle than the data directories. If not set, the default directory is
+# $CASSANDRA_HOME/data/cdc_raw.
+# cdc_raw_directory: /var/lib/cassandra/cdc_raw
+
+# Policy for data disk failures:
+#
+# die
+#   shut down gossip and client transports and kill the JVM for any fs errors or
+#   single-sstable errors, so the node can be replaced.
+#
+# stop_paranoid
+#   shut down gossip and client transports even for single-sstable errors,
+#   kill the JVM for errors during startup.
+#
+# stop
+#   shut down gossip and client transports, leaving the node effectively dead, but
+#   can still be inspected via JMX, kill the JVM for errors during startup.
+#
+# best_effort
+#    stop using the failed disk and respond to requests based on
+#    remaining available sstables.  This means you WILL see obsolete
+#    data at CL.ONE!
+#
+# ignore
+#    ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
 disk_failure_policy: <%= p("disk_failure_policy") %>
+
+# Policy for commit disk failures:
+#
+# die
+#   shut down gossip and Thrift and kill the JVM, so the node can be replaced.
+#
+# stop
+#   shut down gossip and Thrift, leaving the node effectively dead, but
+#   can still be inspected via JMX.
+#
+# stop_commit
+#   shutdown the commit log, letting writes collect but
+#   continuing to service reads, as in pre-2.0.5 Cassandra
+#
+# ignore
+#   ignore fatal errors and let the batches fail
+commit_failure_policy: stop
+
+# Maximum size of the native protocol prepared statement cache
+#
+# Valid values are either "auto" (omitting the value) or a value greater 0.
+#
+# Note that specifying a too large value will result in long running GCs and possbily
+# out-of-memory errors. Keep the value at a small fraction of the heap.
+#
+# If you constantly see "prepared statements discarded in the last minute because
+# cache limit reached" messages, the first step is to investigate the root cause
+# of these messages and check whether prepared statements are used correctly -
+# i.e. use bind markers for variable parts.
+#
+# Do only change the default value, if you really have more prepared statements than
+# fit in the cache. In most cases it is not neccessary to change this value.
+# Constantly re-preparing statements is a performance penalty.
+#
+# Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
+prepared_statements_cache_size_mb:
+
+# Maximum size of the Thrift prepared statement cache
+#
+# If you do not use Thrift at all, it is safe to leave this value at "auto".
+#
+# See description of 'prepared_statements_cache_size_mb' above for more information.
+#
+# Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
+thrift_prepared_statements_cache_size_mb:
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
 key_cache_size_in_mb: <%= p("key_cache_size_in_mb") %>
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
 key_cache_save_period:  <%= p("key_cache_save_period") %>
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Row cache implementation class name. Available implementations:
+#
+# org.apache.cassandra.cache.OHCProvider
+#   Fully off-heap row cache implementation (default).
+#
+# org.apache.cassandra.cache.SerializingCacheProvider
+#   This is the row cache implementation availabile
+#   in previous releases of Cassandra.
+# row_cache_class_name: org.apache.cassandra.cache.OHCProvider
+
+# Maximum size of the row cache in memory.
+# Please note that OHC cache implementation requires some additional off-heap memory to manage
+# the map structures and some in-flight memory during operations before/after cache entries can be
+# accounted against the cache capacity. This overhead is usually small compared to the whole capacity.
+# Do not specify more memory that the system can afford in the worst usual situation and leave some
+# headroom for OS block level cache. Do never allow your system to swap.
+#
+# Default value is 0, to disable row caching.
 row_cache_size_in_mb: <%= p("row_cache_size_in_mb") %>
+
+# Duration in seconds after which Cassandra should save the row cache.
+# Caches are saved to saved_caches_directory as specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
 row_cache_save_period: <%= p("row_cache_save_period") %>
+
+# Number of keys from the row cache to save.
+# Specify 0 (which is the default), meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# Maximum size of the counter cache in memory.
+#
+# Counter cache helps to reduce counter locks' contention for hot counter cells.
+# In case of RF = 1 a counter cache hit will cause Cassandra to skip the read before
+# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
+# of the lock hold, helping with hot counter cell updates, but will not allow skipping
+# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
+# in memory, not the whole counter, so it's relatively cheap.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+counter_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the counter cache (keys only). Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Default is 7200 or 2 hours.
+counter_cache_save_period: 7200
+
+# Number of keys from the counter cache to save
+# Disabled by default, meaning all keys are going to be saved
+# counter_cache_keys_to_save: 100
+
+# saved caches
+# If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
 saved_caches_directory: <%= p("persistent_directory") %>/<%= p("cluster_name") %>/saved_caches
+
+# commitlog_sync may be either "periodic" or "batch." 
+# 
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds. 
 commitlog_sync: <%= p("commitlog_sync") %>
-commitlog_sync_period_in_ms:  <%= p("commitlog_sync_period_in_ms") %>
-commitlog_segment_size_in_mb:  <%= p("commitlog_segment_size_in_mb") %>
+commitlog_sync_period_in_ms: <%= p("commitlog_sync_period_in_ms") %>
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+# Max mutation size is also configurable via max_mutation_size_in_kb setting in
+# cassandra.yaml. The default is half the size commitlog_segment_size_in_mb * 1024.
+# This should be positive and less than 2048.
+#
+# NOTE: If max_mutation_size_in_kb is set explicitly then commitlog_segment_size_in_mb must
+# be set to at least twice the size of max_mutation_size_in_kb / 1024
+#
+commitlog_segment_size_in_mb: <%= p("commitlog_segment_size_in_mb") %>
+
+# Compression to apply to the commit log. If omitted, the commit log
+# will be written uncompressed.  LZ4, Snappy, and Deflate compressors
+# are supported.
+# commitlog_compression:
+#   - class_name: LZ4Compressor
+#     parameters:
+#         -
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
 seed_provider:
+    # Addresses of hosts that are deemed contact points. 
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
     - class_name: org.apache.cassandra.locator.SimpleSeedProvider
       parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
           - seeds: <% link('seeds').instances.each do |instance| %><%= instance.address %>,<% end %>
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
 concurrent_reads: <%= p("concurrent_reads") %>
 concurrent_writes: <%= p("concurrent_writes") %>
+concurrent_counter_writes: 32
+
+# For materialized view writes, as there is a read involved, so this should
+# be limited by the less of concurrent reads or concurrent writes.
+concurrent_materialized_view_writes: 32
+
+# Maximum memory to use for sstable chunk cache and buffer pooling.
+# 32MB of this are reserved for pooling buffers, the rest is used as an
+# cache that holds uncompressed sstable chunks.
+# Defaults to the smaller of 1/4 of heap or 512MB. This pool is allocated off-heap,
+# so is in addition to the memory allocated for heap. The cache also has on-heap
+# overhead which is roughly 128 bytes per chunk (i.e. 0.2% of the reserved size
+# if the default 64k chunk size is used).
+# Memory is only allocated when needed.
 file_cache_size_in_mb: <%= p("file_cache_size_in_mb") %>
+
+# Flag indicating whether to allocate on or off heap when the sstable buffer
+# pool is exhausted, that is when it has exceeded the maximum memory
+# file_cache_size_in_mb, beyond which it will not cache buffers but allocate on request.
+
+# buffer_pool_use_heap_if_exhausted: true
+
+# The strategy for optimizing disk read
+# Possible values are:
+# ssd (for solid state disks, the default)
+# spinning (for spinning disks)
+# disk_optimization_strategy: ssd
+
+# Total permitted memory to use for memtables. Cassandra will stop
+# accepting writes when the limit is exceeded until a flush completes,
+# and will trigger a flush based on memtable_cleanup_threshold
+# If omitted, Cassandra will set both to 1/4 the size of the heap.
+# memtable_heap_space_in_mb: 2048
+# memtable_offheap_space_in_mb: 2048
+
+# memtable_cleanup_threshold is deprecated. The default calculation
+# is the only reasonable choice. See the comments on  memtable_flush_writers
+# for more information.
+#
+# Ratio of occupied non-flushing memtable size to total permitted size
+# that will trigger a flush of the largest memtable. Larger mct will
+# mean larger flushes and hence less compaction, but also less concurrent
+# flush activity which can make it difficult to keep your disks fed
+# under heavy write load.
+#
+# memtable_cleanup_threshold defaults to 1 / (memtable_flush_writers + 1)
+# memtable_cleanup_threshold: 0.11
+
+# Specify the way Cassandra allocates and manages memtable memory.
+# Options are:
+#
+# heap_buffers
+#   on heap nio buffers
+#
+# offheap_buffers
+#   off heap (direct) nio buffers
+#
+# offheap_objects
+#    off heap objects
+memtable_allocation_type: heap_buffers
+
+# Total space to use for commit logs on disk.
+#
+# If space gets above this value, Cassandra will flush every dirty CF
+# in the oldest segment and remove it.  So a small total commitlog space
+# will tend to cause more flush activity on less-active columnfamilies.
+#
+# The default value is the smaller of 8192, and 1/4 of the total space
+# of the commitlog volume.
+#
+# commitlog_total_space_in_mb: 8192
+
+# This sets the number of memtable flush writer threads per disk
+# as well as the total number of memtables that can be flushed concurrently.
+# These are generally a combination of compute and IO bound.
+#
+# Memtable flushing is more CPU efficient than memtable ingest and a single thread
+# can keep up with the ingest rate of a whole server on a single fast disk
+# until it temporarily becomes IO bound under contention typically with compaction.
+# At that point you need multiple flush threads. At some point in the future
+# it may become CPU bound all the time.
+#
+# You can tell if flushing is falling behind using the MemtablePool.BlockedOnAllocation
+# metric which should be 0, but will be non-zero if threads are blocked waiting on flushing
+# to free memory.
+#
+# memtable_flush_writers defaults to two for a single data directory.
+# This means that two  memtables can be flushed concurrently to the single data directory.
+# If you have multiple data directories the default is one memtable flushing at a time
+# but the flush will use a thread per data directory so you will get two or more writers.
+#
+# Two is generally enough to flush on a fast disk [array] mounted as a single data directory.
+# Adding more flush writers will result in smaller more frequent flushes that introduce more
+# compaction overhead.
+#
+# There is a direct tradeoff between number of memtables that can be flushed concurrently
+# and flush size and frequency. More is not better you just need enough flush writers
+# to never stall waiting for flushing to free memory.
+#
 memtable_flush_writers: <%= p("memtable_flush_writers") %>
+
+# Total space to use for change-data-capture logs on disk.
+#
+# If space gets above this value, Cassandra will throw WriteTimeoutException
+# on Mutations including tables with CDC enabled. A CDCCompactor is responsible
+# for parsing the raw CDC logs and deleting them when parsing is completed.
+#
+# The default value is the min of 4096 mb and 1/8th of the total space
+# of the drive where cdc_raw_directory resides.
+# cdc_total_space_in_mb: 4096
+
+# When we hit our cdc_raw limit and the CDCCompactor is either running behind
+# or experiencing backpressure, we check at the following interval to see if any
+# new space for cdc-tracked tables has been made available. Default to 250ms
+# cdc_free_space_check_interval_ms: 250
+
+# A fixed memory pool size in MB for for SSTable index summaries. If left
+# empty, this will default to 5% of the heap size. If the memory usage of
+# all index summaries exceeds this limit, SSTables with low read rates will
+# shrink their index summaries in order to meet this limit.  However, this
+# is a best-effort process. In extreme conditions Cassandra may need to use
+# more than this amount of memory.
+index_summary_capacity_in_mb:
+
+# How frequently index summaries should be resampled.  This is done
+# periodically to redistribute memory from the fixed-size pool to sstables
+# proportional their recent read rates.  Setting to -1 will disable this
+# process, leaving existing index summaries at their current sampling level.
+index_summary_resize_interval_in_minutes: 60
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
 trickle_fsync: <%= p("trickle_fsync") %>
 trickle_fsync_interval_in_kb: <%= p("trickle_fsync_interval_in_kb") %>
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
 storage_port: <%= p("storage_port") %>
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
 ssl_storage_port: <%= p("ssl_storage_port") %>
+
+# Address or interface to bind to and tell other Cassandra nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# Set listen_address OR listen_interface, not both.
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting listen_address to 0.0.0.0 is always wrong.
+#
+listen_address: localhost
+
+# Set listen_address OR listen_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# listen_interface: eth0
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using listen_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# listen_interface_prefer_ipv6: false
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+# When using multiple physical network interfaces, set this
+# to true to listen on broadcast_address in addition to
+# the listen_address, allowing nodes to communicate in both
+# interfaces.
+# Ignore this property if the network configuration automatically
+# routes  between the public and private networks such as EC2.
+# listen_on_broadcast_address: false
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+native_transport_port: 9042
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+# native_transport_port_ssl: 9142
+# The maximum threads for handling requests when the native transport is used.
+# This is similar to rpc_max_threads though the default differs slightly (and
+# there is no native_transport_min_threads, idle threads will always be stopped
+# after 30 seconds).
+# native_transport_max_threads: 128
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB. If you're changing this parameter,
+# you may want to adjust max_value_size_in_mb accordingly. This should be positive and less than 2048.
+# native_transport_max_frame_size_in_mb: 256
+
+# The maximum number of concurrent client connections.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections: -1
+
+# The maximum number of concurrent client connections per source ip.
+# The default is -1, which means unlimited.
+# native_transport_max_concurrent_connections_per_ip: -1
+
+# Whether to start the thrift rpc server.
+start_rpc: false
+
+# The address or interface to bind the Thrift RPC service and native transport
+# server to.
+#
+# Set rpc_address OR rpc_interface, not both.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+rpc_address: localhost
+
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+# rpc_interface: eth1
+
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+# rpc_interface_prefer_ipv6: false
+
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+# broadcast_rpc_address: 1.2.3.4
+
+# enable or disable keepalive on rpc/native connections
+rpc_keepalive: true
+
+# Cassandra provides two out-of-the-box options for the RPC Server:
+#
+# sync
+#   One thread per thrift connection. For a very large number of clients, memory
+#   will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size
+#   per thread, and that will correspond to your use of virtual memory (but physical memory
+#   may be limited depending on use of stack space).
+#
+# hsha
+#   Stands for "half synchronous, half asynchronous." All thrift clients are handled
+#   asynchronously using a small number of threads that does not vary with the amount
+#   of thrift clients (and thus scales well to many clients). The rpc requests are still
+#   synchronous (one thread per active request). If hsha is selected then it is essential
+#   that rpc_max_threads is changed from the default value of unlimited.
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+#
+# Alternatively,  can provide your own RPC server by providing the fully-qualified class name
+# of an o.a.c.t.TServerFactory that can create an instance of it.
+rpc_server_type: sync
+
+# Uncomment rpc_min|max_thread to set request pool size limits.
+#
+# Regardless of your choice of RPC server (see above), the number of maximum requests in the
+# RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
+# RPC server, it also dictates the number of clients that can be connected at all).
+#
+# The default is unlimited and thus provides no protection against clients overwhelming the server. You are
+# encouraged to set a maximum that makes sense for you in production, but do keep in mind that
+# rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+
+# uncomment to set socket buffer sizes on rpc connections
+# rpc_send_buff_size_in_bytes:
+# rpc_recv_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See also:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and 'man tcp'
+# internode_send_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# internode_recv_buff_size_in_bytes:
+
+# Frame size for thrift (maximum message length).
+thrift_framed_transport_size_in_mb: 15
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true 
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#
+# - a smaller granularity means more index entries are generated
+#   and looking up rows withing the partition by collation column
+#   is faster
+# - but, Cassandra will keep the collation index in memory for hot
+#   rows (as part of the key cache), so a larger granularity means
+#   you can cache more hot rows
+column_index_size_in_kb: 64
+
+# Per sstable indexed key cache entries (the collation index in memory
+# mentioned above) exceeding this size will not be held on heap.
+# This means that only partition information is held on heap and the
+# index entries are read from disk.
+#
+# Note that this size refers to the size of the
+# serialized index information and not the size of the partition.
+column_index_cache_size_in_kb: 2
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# concurrent_compactors defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+# 
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+#concurrent_compactors: 1
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: 16
+
+# When compacting, the replacement sstable(s) can be opened before they
+# are completely written, and used in place of the prior sstables for
+# any range that has been written. This helps to smoothly transfer reads 
+# between the sstables, reducing page cache churn and keeping hot rows hot
+sstable_preemptive_open_interval_in_mb: 50
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# Throttles all streaming file transfer between the datacenters,
+# this setting allows users to throttle inter dc stream throughput in addition
+# to throttling all network stream traffic as configured with
+# stream_throughput_outbound_megabits_per_sec
+# When unset, the default is 200 Mbps or 25 MB/s
+# inter_dc_stream_throughput_outbound_megabits_per_sec: 200
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+# How long the coordinator should wait for seq or index scans to complete
+range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# How long the coordinator should wait for counter writes to complete
+counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+request_timeout_in_ms: 10000
+
+# How long before a node logs slow queries. Select queries that take longer than
+# this timeout to execute, will generate an aggregated log message, so that slow queries
+# can be identified. Set this value to zero to disable slow query logging.
+slow_query_log_timeout_in_ms: 500
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing 
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+
+# Set keep-alive period for streaming
+# This node will send a keep-alive message periodically with this period.
+# If the node does not receive a keep-alive message from the peer for
+# 2 keep-alive cycles the stream session times out and fail
+# Default value is 300s (5 minutes), which means stalled stream
+# times out in 10 minutes by default
+# streaming_keep_alive_period_in_secs: 300
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+#
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# CASSANDRA WILL NOT ALLOW YOU TO SWITCH TO AN INCOMPATIBLE SNITCH
+# ONCE DATA IS INSERTED INTO THE CLUSTER.  This would cause data loss.
+# This means that if you start with the default SimpleSnitch, which
+# locates every node on "rack1" in "datacenter1", your only options
+# if you need to add another datacenter are GossipingPropertyFileSnitch
+# (and the older PFS).  From there, if you want to migrate to an
+# incompatible snitch like Ec2Snitch you can do it by adding new nodes
+# under Ec2Snitch (which will locate them in a new "datacenter") and
+# decommissioning the old ones.
+#
+# Out of the box, Cassandra provides:
+#
+# SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#
+# GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#
+# PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#
+# Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#
+# Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#
+# RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100 
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero and read_repair_chance is < 1.0, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# request_scheduler -- Set this to a class that implements
+# RequestScheduler, which will schedule incoming client requests
+# according to the specific policy. This is useful for multi-tenancy
+# with a single Cassandra cluster.
+# NOTE: This is specifically for requests from the client and does
+# not affect inter node communication.
+# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
+# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
+# client requests to a node with a separate queue for each
+# request_scheduler_id. The scheduler is further customized by
+# request_scheduler_options as described below.
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+
+# Scheduler Options vary based on the type of scheduler
+#
+# NoScheduler
+#   Has no options
+#
+# RoundRobin
+#   throttle_limit
+#     The throttle_limit is the number of in-flight
+#     requests per client.  Requests beyond 
+#     that limit are queued up until
+#     running requests can complete.
+#     The value of 80 here is twice the number of
+#     concurrent_reads + concurrent_writes.
+#   default_weight
+#     default_weight is optional and allows for
+#     overriding the default which is 1.
+#   weights
+#     Weights are optional and will default to 1 or the
+#     overridden default_weight. The weight translates into how
+#     many requests are handled during each turn of the
+#     RoundRobin, based on the scheduler id.
+#
+# request_scheduler_options:
+#    throttle_limit: 80
+#    default_weight: 5
+#    weights:
+#      Keyspace1: 1
+#      Keyspace2: 5
+
+# request_scheduler_id -- An identifier based on which to perform
+# the request scheduling. Currently the only valid option is keyspace.
+# request_scheduler_id: keyspace
+
+# Enable or disable inter-node encryption
+# JVM defaults for supported SSL socket protocols and cipher suites can
+# be replaced using custom encryption options. This is not recommended
+# unless you have policies in place that dictate certain settings, or
+# need to disable vulnerable ciphers or protocols in case the JVM cannot
+# be updated.
+# FIPS compliant settings can be configured at JVM level and should not
+# involve changing encryption settings here:
+# https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/FIPS.html
+# *NOTE* No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+#
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+server_encryption_options:
+    internode_encryption: none
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    truststore: conf/.truststore
+    truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+    # require_client_auth: false
+    # require_endpoint_verification: false
+
+# enable or disable client/server encryption.
+client_encryption_options:
+    enabled: false
+    # If enabled and optional is set to true encrypted and unencrypted connections are handled.
+    optional: false
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    # require_client_auth: false
+    # Set trustore and truststore_password if require_client_auth is true
+    # truststore: conf/.truststore
+    # truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# Can be:
+#
+# all
+#   all traffic is compressed
+#
+# dc
+#   traffic between different datacenters is compressed
+#
+# none
+#   nothing is compressed.
+internode_compression: dc
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+inter_dc_tcp_nodelay: false
+
+# TTL for different trace types used during logging of the repair process.
+tracetype_query_ttl: 86400
+tracetype_repair_ttl: 604800
+
+# By default, Cassandra logs GC Pauses greater than 200 ms at INFO level
+# This threshold can be adjusted to minimize logging if necessary
+# gc_log_threshold_in_ms: 200
+
+# If unset, all GC Pauses greater than gc_log_threshold_in_ms will log at
+# INFO level
+# UDFs (user defined functions) are disabled by default.
+# As of Cassandra 3.0 there is a sandbox in place that should prevent execution of evil code.
+enable_user_defined_functions: false
+
+# Enables scripted UDFs (JavaScript UDFs).
+# Java UDFs are always enabled, if enable_user_defined_functions is true.
+# Enable this option to be able to use UDFs with "language javascript" or any custom JSR-223 provider.
+# This option has no effect, if enable_user_defined_functions is false.
+enable_scripted_user_defined_functions: false
+
+# The default Windows kernel timer and scheduling resolution is 15.6ms for power conservation.
+# Lowering this value on Windows can provide much tighter latency and better throughput, however
+# some virtualized environments may see a negative performance impact from changing this setting
+# below their system default. The sysinternals 'clockres' tool can confirm your system's default
+# setting.
+windows_timer_interval: 1
+
+
+# Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
+# a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
+# the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys
+# can still (and should!) be in the keystore and will be used on decrypt operations
+# (to handle the case of key rotation).
+#
+# It is strongly recommended to download and install Java Cryptography Extension (JCE)
+# Unlimited Strength Jurisdiction Policy Files for your version of the JDK.
+# (current link: http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
+#
+# Currently, only the following file types are supported for transparent data encryption, although
+# more are coming in future cassandra releases: commitlog, hints
+transparent_data_encryption_options:
+    enabled: false
+    chunk_length_kb: 64
+    cipher: AES/CBC/PKCS5Padding
+    key_alias: testing:1
+    # CBC IV length for AES needs to be 16 bytes (which is also the default size)
+    # iv_length: 16
+    key_provider: 
+      - class_name: org.apache.cassandra.security.JKSKeyProvider
+        parameters: 
+          - keystore: conf/.keystore
+            keystore_password: cassandra
+            store_type: JCEKS
+            key_password: cassandra
+
+
+#####################
+# SAFETY THRESHOLDS #
+#####################
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: 1000
+tombstone_failure_threshold: 100000
+
+# Log WARN on any multiple-partition batch size exceeding this value. 5kb per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 5
+
+# Fail any multiple-partition batch exceeding this value. 50kb (10x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 50
+
+# Log WARN on any batches not of type LOGGED than span across more partitions than this limit
+unlogged_batch_across_partitions_warn_threshold: 10
+
+# Log a warning when compacting partitions larger than this value
+compaction_large_partition_warning_threshold_mb: 100
+
+# GC Pauses greater than gc_warn_threshold_in_ms will be logged at WARN level
+# Adjust the threshold based on your application throughput requirement
+# By default, Cassandra logs GC Pauses greater than 200 ms at INFO level
+gc_warn_threshold_in_ms: 1000
+
+# Maximum size of any value in SSTables. Safety measure to detect SSTable corruption
+# early. Any value size larger than this threshold will result into marking an SSTable
+# as corrupted. This should be positive and less than 2048.
+# max_value_size_in_mb: 256
+
+# Back-pressure settings #
+# If enabled, the coordinator will apply the back-pressure strategy specified below to each mutation
+# sent to replicas, with the aim of reducing pressure on overloaded replicas.
+back_pressure_enabled: false
+# The back-pressure strategy applied.
+# The default implementation, RateBasedBackPressure, takes three arguments:
+# high ratio, factor, and flow type, and uses the ratio between incoming mutation responses and outgoing mutation requests.
+# If below high ratio, outgoing mutations are rate limited according to the incoming rate decreased by the given factor;
+# if above high ratio, the rate limiting is increased by the given factor;
+# such factor is usually best configured between 1 and 10, use larger values for a faster recovery
+# at the expense of potentially more dropped mutations;
+# the rate limiting is applied according to the flow type: if FAST, it's rate limited at the speed of the fastest replica,
+# if SLOW at the speed of the slowest one.
+# New strategies can be added. Implementors need to implement org.apache.cassandra.net.BackpressureStrategy and
+# provide a public constructor accepting a Map<String, Object>.
+back_pressure_strategy:
+    - class_name: org.apache.cassandra.net.RateBasedBackPressure
+      parameters:
+        - high_ratio: 0.90
+          factor: 5
+          flow: FAST
+
+# Coalescing Strategies #
+# Coalescing multiples messages turns out to significantly boost message processing throughput (think doubling or more).
+# On bare metal, the floor for packet processing throughput is high enough that many applications won't notice, but in
+# virtualized environments, the point at which an application can be bound by network packet processing can be
+# surprisingly low compared to the throughput of task processing that is possible inside a VM. It's not that bare metal
+# doesn't benefit from coalescing messages, it's that the number of packets a bare metal network interface can process
+# is sufficient for many applications such that no load starvation is experienced even without coalescing.
+# There are other benefits to coalescing network messages that are harder to isolate with a simple metric like messages
+# per second. By coalescing multiple tasks together, a network thread can process multiple messages for the cost of one
+# trip to read from a socket, and all the task submission work can be done at the same time reducing context switching
+# and increasing cache friendliness of network message processing.
+# See CASSANDRA-8692 for details.
+
+# Strategy to use for coalescing messages in OutboundTcpConnection.
+# Can be fixed, movingaverage, timehorizon, disabled (default).
+# You can also specify a subclass of CoalescingStrategies.CoalescingStrategy by name.
+# otc_coalescing_strategy: DISABLED
+
+# How many microseconds to wait for coalescing. For fixed strategy this is the amount of time after the first
+# message is received before it will be sent with any accompanying messages. For moving average this is the
+# maximum amount of time that will be waited as well as the interval at which messages must arrive on average
+# for coalescing to be enabled.
+# otc_coalescing_window_us: 200
+
+# Do not try to coalesce messages if we already got that many messages. This should be more than 2 and less than 128.
+# otc_coalescing_enough_coalesced_messages: 8
+
+# How many milliseconds to wait between two expiration runs on the backlog (queue) of the OutboundTcpConnection.
+# Expiration is done if messages are piling up in the backlog. Droppable messages are expired to free the memory
+# taken by expired messages. The interval should be between 0 and 1000, and in most installations the default value
+# will be appropriate. A smaller value could potentially expire messages slightly sooner at the expense of more CPU
+# time and queue contention while iterating the backlog of messages.
+# An interval of 0 disables any wait time, which is the behavior of former Cassandra versions.
+#
+# otc_backlog_expiration_interval_ms: 200
+
 listen_address: <%= spec.ip %>
 start_native_transport: <%= p("start_native_transport") %>
 native_transport_port: <%= p("native_transport_port") %>
@@ -69,17 +1268,17 @@ request_scheduler: <%= p("request_scheduler") %>
 internode_compression: <%= p("internode_compression") %>
 inter_dc_tcp_nodelay: <%= p("inter_dc_tcp_nodelay") %>
 server_encryption_options:
- internode_encryption: <%= p("internode_encryption_mode") %>
- keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
- keystore_password: <%= p("cass_KSP") %>
- truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
- truststore_password: <%= p("cass_KSP") %>
- protocol: TLS
+  internode_encryption: <%= p("internode_encryption_mode") %>
+  keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
+  keystore_password: <%= p("cass_KSP") %>
+  truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
+  truststore_password: <%= p("cass_KSP") %>
+  protocol: TLS
 client_encryption_options:
- enabled: <%= p("client_encryption.enabled") %>
- keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
- keystore_password: <%= p("cass_KSP") %>
- truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
- truststore_password: <%= p("cass_KSP") %>
- require_client_auth: <%= p("client_encryption.require_client_auth") %>
- protocol: TLS
+  enabled: <%= p("client_encryption.enabled") %>
+  keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
+  keystore_password: <%= p("cass_KSP") %>
+  truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
+  truststore_password: <%= p("cass_KSP") %>
+  require_client_auth: <%= p("client_encryption.require_client_auth") %>
+  protocol: TLS

--- a/jobs/cassandra/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra/templates/config/cassandra.yaml.erb
@@ -596,7 +596,7 @@ ssl_storage_port: <%= p("ssl_storage_port") %>
 #
 # Setting listen_address to 0.0.0.0 is always wrong.
 #
-listen_address: localhost
+listen_address: <%= spec.ip %>
 
 # Set listen_address OR listen_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.
@@ -627,10 +627,10 @@ listen_address: localhost
 # Whether to start the native transport server.
 # Please note that the address on which the native transport is bound is the
 # same as the rpc_address. The port however is different and specified below.
-start_native_transport: true
+start_native_transport: <%= p("start_native_transport") %>
 # port for the CQL native transport to listen for clients on
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-native_transport_port: 9042
+native_transport_port: <%= p("native_transport_port") %>
 # Enabling native transport encryption in client_encryption_options allows you to either use
 # encryption for the standard port or to use a dedicated, additional port along with the unencrypted
 # standard native_transport_port.
@@ -643,12 +643,12 @@ native_transport_port: 9042
 # This is similar to rpc_max_threads though the default differs slightly (and
 # there is no native_transport_min_threads, idle threads will always be stopped
 # after 30 seconds).
-# native_transport_max_threads: 128
+native_transport_max_threads: <%= p("native_transport_max_threads") %>
 #
 # The maximum size of allowed frame. Frame (requests) larger than this will
 # be rejected as invalid. The default is 256MB. If you're changing this parameter,
 # you may want to adjust max_value_size_in_mb accordingly. This should be positive and less than 2048.
-# native_transport_max_frame_size_in_mb: 256
+native_transport_max_frame_size_in_mb: <%= p("native_transport_max_frame_size_in_mb") %>
 
 # The maximum number of concurrent client connections.
 # The default is -1, which means unlimited.
@@ -659,7 +659,7 @@ native_transport_port: 9042
 # native_transport_max_concurrent_connections_per_ip: -1
 
 # Whether to start the thrift rpc server.
-start_rpc: false
+start_rpc: <%= p("start_rpc") %>
 
 # The address or interface to bind the Thrift RPC service and native transport
 # server to.
@@ -673,7 +673,7 @@ start_rpc: false
 # set broadcast_rpc_address to a value other than 0.0.0.0.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-rpc_address: localhost
+rpc_address: <%= spec.ip %>
 
 # Set rpc_address OR rpc_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.
@@ -686,7 +686,7 @@ rpc_address: localhost
 # rpc_interface_prefer_ipv6: false
 
 # port for Thrift to listen for clients on
-rpc_port: 9160
+rpc_port: <%= p("rpc_port") %>
 
 # RPC address to broadcast to drivers and other Cassandra nodes. This cannot
 # be set to 0.0.0.0. If left blank, this will be set to the value of
@@ -695,7 +695,7 @@ rpc_port: 9160
 # broadcast_rpc_address: 1.2.3.4
 
 # enable or disable keepalive on rpc/native connections
-rpc_keepalive: true
+rpc_keepalive: <%= p("rpc_keepalive") %>
 
 # Cassandra provides two out-of-the-box options for the RPC Server:
 #
@@ -717,7 +717,7 @@ rpc_keepalive: true
 #
 # Alternatively,  can provide your own RPC server by providing the fully-qualified class name
 # of an o.a.c.t.TServerFactory that can create an instance of it.
-rpc_server_type: sync
+rpc_server_type: <%= p("rpc_server_type") %>
 
 # Uncomment rpc_min|max_thread to set request pool size limits.
 #
@@ -729,8 +729,8 @@ rpc_server_type: sync
 # encouraged to set a maximum that makes sense for you in production, but do keep in mind that
 # rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
 #
-# rpc_min_threads: 16
-# rpc_max_threads: 2048
+rpc_min_threads: <%= p("rpc_min_threads") %>
+rpc_max_threads: <%= p("rpc_max_threads") %>
 
 # uncomment to set socket buffer sizes on rpc connections
 # rpc_send_buff_size_in_bytes:
@@ -753,25 +753,25 @@ rpc_server_type: sync
 # internode_recv_buff_size_in_bytes:
 
 # Frame size for thrift (maximum message length).
-thrift_framed_transport_size_in_mb: 15
+thrift_framed_transport_size_in_mb: <%= p("thrift_framed_transport_size_in_mb") %>
 
 # Set to true to have Cassandra create a hard link to each sstable
 # flushed or streamed locally in a backups/ subdirectory of the
 # keyspace data.  Removing these links is the operator's
 # responsibility.
-incremental_backups: false
+incremental_backups: <%= p("incremental_backups") %>
 
 # Whether or not to take a snapshot before each compaction.  Be
 # careful using this option, since Cassandra won't clean up the
 # snapshots for you.  Mostly useful if you're paranoid when there
 # is a data format change.
-snapshot_before_compaction: false
+snapshot_before_compaction: <%= p("snapshot_before_compaction") %>
 
 # Whether or not a snapshot is taken of the data before keyspace truncation
 # or dropping of column families. The STRONGLY advised default of true 
 # should be used to provide data safety. If you set this flag to false, you will
 # lose data on truncation or drop.
-auto_snapshot: true
+auto_snapshot: <%= p("auto_snapshot") %>
 
 # Granularity of the collation index of rows within a partition.
 # Increase if your rows are large, or if you have a very large
@@ -783,7 +783,7 @@ auto_snapshot: true
 # - but, Cassandra will keep the collation index in memory for hot
 #   rows (as part of the key cache), so a larger granularity means
 #   you can cache more hot rows
-column_index_size_in_kb: 64
+column_index_size_in_kb: <%= p("column_index_size_in_kb") %>
 
 # Per sstable indexed key cache entries (the collation index in memory
 # mentioned above) exceeding this size will not be held on heap.
@@ -808,7 +808,7 @@ column_index_cache_size_in_kb: 2
 # 
 # If your data directories are backed by SSD, you should increase this
 # to the number of cores.
-#concurrent_compactors: 1
+concurrent_compactors: <%= p("concurrent_compactors") %>
 
 # Throttles compaction to the given total throughput across the entire
 # system. The faster you insert data, the faster you need to compact in
@@ -839,22 +839,22 @@ sstable_preemptive_open_interval_in_mb: 50
 # inter_dc_stream_throughput_outbound_megabits_per_sec: 200
 
 # How long the coordinator should wait for read operations to complete
-read_request_timeout_in_ms: 5000
+read_request_timeout_in_ms: <%= p("read_request_timeout_in_ms") %>
 # How long the coordinator should wait for seq or index scans to complete
-range_request_timeout_in_ms: 10000
+range_request_timeout_in_ms: <%= p("range_request_timeout_in_ms") %>
 # How long the coordinator should wait for writes to complete
-write_request_timeout_in_ms: 2000
+write_request_timeout_in_ms: <%= p("write_request_timeout_in_ms") %>
 # How long the coordinator should wait for counter writes to complete
 counter_write_request_timeout_in_ms: 5000
 # How long a coordinator should continue to retry a CAS operation
 # that contends with other proposals for the same row
-cas_contention_timeout_in_ms: 1000
+cas_contention_timeout_in_ms: <%= p("cas_contention_timeout_in_ms") %>
 # How long the coordinator should wait for truncates to complete
 # (This can be much longer, because unless auto_snapshot is disabled
 # we need to flush first so we can snapshot before removing the data.)
-truncate_request_timeout_in_ms: 60000
+truncate_request_timeout_in_ms: <%= p("truncate_request_timeout_in_ms") %>
 # The default timeout for other, miscellaneous operations
-request_timeout_in_ms: 10000
+request_timeout_in_ms: <%= p("request_timeout_in_ms") %>
 
 # How long before a node logs slow queries. Select queries that take longer than
 # this timeout to execute, will generate an aggregated log message, so that slow queries
@@ -869,7 +869,7 @@ slow_query_log_timeout_in_ms: 500
 #
 # Warning: before enabling this property make sure to ntp is installed
 # and the times are synchronized between the nodes.
-cross_node_timeout: false
+cross_node_timeout: <%= p("cross_node_timeout") %>
 
 # Set keep-alive period for streaming
 # This node will send a keep-alive message periodically with this period.
@@ -881,7 +881,7 @@ cross_node_timeout: false
 
 # phi value that must be reached for a host to be marked down.
 # most users should never need to adjust this.
-# phi_convict_threshold: 8
+phi_convict_threshold: <%= p("phi_convict_threshold") %>
 
 # endpoint_snitch -- Set this to a class that implements
 # IEndpointSnitch.  The snitch has two functions:
@@ -946,14 +946,14 @@ cross_node_timeout: false
 #
 # You can use a custom Snitch by setting this to the full class name
 # of the snitch, which will be assumed to be on your classpath.
-endpoint_snitch: SimpleSnitch
+endpoint_snitch: <%= p("endpoint_snitch") %>
 
 # controls how often to perform the more expensive part of host score
 # calculation
-dynamic_snitch_update_interval_in_ms: 100 
+dynamic_snitch_update_interval_in_ms: <%= p("dynamic_snitch_update_interval_in_ms") %>
 # controls how often to reset all host scores, allowing a bad host to
 # possibly recover
-dynamic_snitch_reset_interval_in_ms: 600000
+dynamic_snitch_reset_interval_in_ms: <%= p("dynamic_snitch_reset_interval_in_ms") %>
 # if set greater than zero and read_repair_chance is < 1.0, this will allow
 # 'pinning' of replicas to hosts in order to increase cache capacity.
 # The badness threshold will control how much worse the pinned host has to be
@@ -961,7 +961,7 @@ dynamic_snitch_reset_interval_in_ms: 600000
 # expressed as a double which represents a percentage.  Thus, a value of
 # 0.2 means Cassandra would continue to prefer the static snitch values
 # until the pinned host was 20% worse than the fastest.
-dynamic_snitch_badness_threshold: 0.1
+dynamic_snitch_badness_threshold: <%= p("dynamic_snitch_badness_threshold") %>
 
 # request_scheduler -- Set this to a class that implements
 # RequestScheduler, which will schedule incoming client requests
@@ -974,7 +974,7 @@ dynamic_snitch_badness_threshold: 0.1
 # client requests to a node with a separate queue for each
 # request_scheduler_id. The scheduler is further customized by
 # request_scheduler_options as described below.
-request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+request_scheduler: <%= p("request_scheduler") %>
 
 # Scheduler Options vary based on the type of scheduler
 #
@@ -1029,11 +1029,12 @@ request_scheduler: org.apache.cassandra.scheduler.NoScheduler
 # http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
 #
 server_encryption_options:
-    internode_encryption: none
-    keystore: conf/.keystore
-    keystore_password: cassandra
-    truststore: conf/.truststore
-    truststore_password: cassandra
+    internode_encryption: <%= p("internode_encryption_mode") %>
+    keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
+    keystore_password: <%= p("cass_KSP") %>
+    truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
+    truststore_password: <%= p("cass_KSP") %>
+    protocol: TLS
     # More advanced defaults below:
     # protocol: TLS
     # algorithm: SunX509
@@ -1044,17 +1045,19 @@ server_encryption_options:
 
 # enable or disable client/server encryption.
 client_encryption_options:
-    enabled: false
+    enabled: <%= p("client_encryption.enabled") %>
     # If enabled and optional is set to true encrypted and unencrypted connections are handled.
     optional: false
-    keystore: conf/.keystore
-    keystore_password: cassandra
-    # require_client_auth: false
+    keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
+    keystore_password: <%= p("cass_KSP") %>
+
+    require_client_auth: <%= p("client_encryption.require_client_auth") %>
     # Set trustore and truststore_password if require_client_auth is true
-    # truststore: conf/.truststore
-    # truststore_password: cassandra
+    truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
+    truststore_password: <%= p("cass_KSP") %>
+
     # More advanced defaults below:
-    # protocol: TLS
+    protocol: TLS
     # algorithm: SunX509
     # store_type: JKS
     # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
@@ -1071,13 +1074,13 @@ client_encryption_options:
 #
 # none
 #   nothing is compressed.
-internode_compression: dc
+internode_compression: <%= p("internode_compression") %>
 
 # Enable or disable tcp_nodelay for inter-dc communication.
 # Disabling it will result in larger (but fewer) network packets being sent,
 # reducing overhead from the TCP protocol itself, at the cost of increasing
 # latency if you block for cross-datacenter responses.
-inter_dc_tcp_nodelay: false
+inter_dc_tcp_nodelay: <%= p("inter_dc_tcp_nodelay") %>
 
 # TTL for different trace types used during logging of the repair process.
 tracetype_query_ttl: 86400
@@ -1148,8 +1151,8 @@ transparent_data_encryption_options:
 # Adjust the thresholds here if you understand the dangers and want to
 # scan more tombstones anyway.  These thresholds may also be adjusted at runtime
 # using the StorageService mbean.
-tombstone_warn_threshold: 1000
-tombstone_failure_threshold: 100000
+tombstone_warn_threshold: <%= p("tombstone_warn_threshold") %>
+tombstone_failure_threshold: <%= p("tombstone_failure_threshold") %>
 
 # Log WARN on any multiple-partition batch size exceeding this value. 5kb per batch by default.
 # Caution should be taken on increasing the size of this threshold as it can lead to node instability.
@@ -1231,54 +1234,3 @@ back_pressure_strategy:
 # An interval of 0 disables any wait time, which is the behavior of former Cassandra versions.
 #
 # otc_backlog_expiration_interval_ms: 200
-
-listen_address: <%= spec.ip %>
-start_native_transport: <%= p("start_native_transport") %>
-native_transport_port: <%= p("native_transport_port") %>
-native_transport_max_threads: <%= p("native_transport_max_threads") %>
-native_transport_max_frame_size_in_mb: <%= p("native_transport_max_frame_size_in_mb") %>
-start_rpc: <%= p("start_rpc") %>
-rpc_address: <%=spec.ip%>
-rpc_port: <%= p("rpc_port") %>
-rpc_keepalive: <%= p("rpc_keepalive") %>
-rpc_server_type: <%= p("rpc_server_type") %>
-rpc_min_threads: <%= p("rpc_min_threads") %>
-rpc_max_threads: <%= p("rpc_max_threads") %>
-thrift_framed_transport_size_in_mb: <%= p("thrift_framed_transport_size_in_mb") %>
-incremental_backups: <%= p("incremental_backups") %>
-snapshot_before_compaction: <%= p("snapshot_before_compaction") %>
-auto_snapshot: <%= p("auto_snapshot") %>
-tombstone_warn_threshold: <%= p("tombstone_warn_threshold") %>
-tombstone_failure_threshold: <%= p("tombstone_failure_threshold") %>
-column_index_size_in_kb: <%= p("column_index_size_in_kb") %>
-concurrent_compactors: <%= p("concurrent_compactors") %>
-read_request_timeout_in_ms: <%= p("read_request_timeout_in_ms") %>
-range_request_timeout_in_ms: <%= p("range_request_timeout_in_ms") %>
-write_request_timeout_in_ms: <%= p("write_request_timeout_in_ms") %>
-cas_contention_timeout_in_ms: <%= p("cas_contention_timeout_in_ms") %>
-truncate_request_timeout_in_ms: <%= p("truncate_request_timeout_in_ms") %>
-request_timeout_in_ms: <%= p("request_timeout_in_ms") %>
-cross_node_timeout: <%= p("cross_node_timeout") %>
-phi_convict_threshold: <%= p("phi_convict_threshold") %>
-endpoint_snitch: <%= p("endpoint_snitch") %>
-dynamic_snitch_update_interval_in_ms: <%= p("dynamic_snitch_update_interval_in_ms") %>
-dynamic_snitch_reset_interval_in_ms: <%= p("dynamic_snitch_reset_interval_in_ms") %>
-dynamic_snitch_badness_threshold: <%= p("dynamic_snitch_badness_threshold") %>
-request_scheduler: <%= p("request_scheduler") %>
-internode_compression: <%= p("internode_compression") %>
-inter_dc_tcp_nodelay: <%= p("inter_dc_tcp_nodelay") %>
-server_encryption_options:
-  internode_encryption: <%= p("internode_encryption_mode") %>
-  keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
-  keystore_password: <%= p("cass_KSP") %>
-  truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
-  truststore_password: <%= p("cass_KSP") %>
-  protocol: TLS
-client_encryption_options:
-  enabled: <%= p("client_encryption.enabled") %>
-  keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
-  keystore_password: <%= p("cass_KSP") %>
-  truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
-  truststore_password: <%= p("cass_KSP") %>
-  require_client_auth: <%= p("client_encryption.require_client_auth") %>
-  protocol: TLS


### PR DESCRIPTION
In this PR, we initiated a full review of Cassandra configuration properties.

### Done
- Align config properties with those from Cassandra 3.11.1 upstream distribution.
- Enrich `cassandra` job `spec` file with selected and curated documentation, so that the operator consuming the Bosh Release can decide whether to tweak some settings or not.
