### PR TITLE
[to merge 3rd] Escape injected properties in templates

### DIFF
--- a/deployment/cassandra.yml
+++ b/deployment/cassandra.yml
@@ -3,7 +3,7 @@ name: cassandra
 
 instance_groups:
   - name: cassandra-seeds
-    instances: &cassandra_seeds_count 3
+    instances: 3
     azs: [ z1, z2, z3 ]
     jobs:
       - name: cassandra
@@ -13,7 +13,6 @@ instance_groups:
         consumes:
           seeds: { from: *cassandra_seeds_link }
         properties: &cassandra_properties
-          system_auth_keyspace_replication_factor: *cassandra_seeds_count
           cluster_name: &cassandra_cluster_name cluster
           num_tokens: 256
           internode_encryption_mode: none

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -780,7 +780,11 @@ properties:
     description: |
       The replication factor to apply to the 'system_auth' keyspace that holds
       users and passwords.
-    default: 3
+
+      When this value is nor defined or 'null', the default replication factor
+      used is the number of seeds instances, as can be inferred when
+      traversing the 'seeds' Bosh Link.
+    default: null
 
   disable_linux_swap:
     description: |

--- a/jobs/cassandra/templates/bin/post-start.sh
+++ b/jobs/cassandra/templates/bin/post-start.sh
@@ -70,12 +70,17 @@ fi
 
 
 log_err "INFO: setting replication strategy for cassandra password"
+<%
+  require "json"
+
+  replication_factor = p('system_auth_keyspace_replication_factor', link('seeds').instances.count)
+-%>
 # Note: should we support multiple datacenters one day, then we should set the
 # replication class to 'NetworkTopologyStrategy' here instead of 'SimpleStrategy'.
 # See: <https://docs.datastax.com/en/cassandra/latest/cassandra/configuration/configCassandra_yaml.html#configCassandra_yaml__authenticator>
 # See: <https://docs.datastax.com/en/cassandra/latest/cassandra/configuration/configCassandra_yaml.html#configCassandra_yaml__authorizer>
 $CASSANDRA_BIN/cqlsh --cqlshrc "$job_dir/root/.cassandra/cqlshrc" \
-     -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '<%= p('system_auth_keyspace_replication_factor') %>'}  AND durable_writes = true"
+     -e 'alter keyspace system_auth WITH replication = {"class": "SimpleStrategy", "replication_factor": <%= replication_factor.to_json %>}  AND durable_writes = true'
 
 log_err "INFO: propagating any new password with the enforced replication strategy"
 $job_dir/bin/nodetool repair system_auth

--- a/jobs/cassandra/templates/config/cassandra-env.sh.erb
+++ b/jobs/cassandra/templates/config/cassandra-env.sh.erb
@@ -13,6 +13,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+-%>
 
 calculate_heap_sizes()
 {
@@ -122,7 +129,7 @@ case "$jvm" in
 esac
 
 #GC log path has to be defined here because it needs to access CASSANDRA_HOME
-JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
+#JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
 
 # Here we create the arguments that will get passed to the jvm when
 # starting cassandra.
@@ -161,8 +168,8 @@ USING_G1=$?
 # times. If in doubt, and if you do not particularly want to tweak, go with
 # 100 MB per physical CPU core.
 
-MAX_HEAP_SIZE="<%= p("max_heap_size") %>"
-HEAP_NEWSIZE="<%= p("heap_newsize") %>"
+MAX_HEAP_SIZE=<%= esc(p("max_heap_size")) %>
+HEAP_NEWSIZE=<%= esc(p("heap_newsize")) %>
 
 # Set this to control the amount of arenas per-thread in glibc
 #export MALLOC_ARENA_MAX=4

--- a/jobs/cassandra/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra/templates/config/cassandra.yaml.erb
@@ -1,4 +1,7 @@
 # Cassandra storage config YAML
+<%
+  require "json"
+-%>
 
 # NOTE:
 #   See http://wiki.apache.org/cassandra/StorageConfiguration for
@@ -7,7 +10,7 @@
 
 # The name of the cluster. This is mainly used to prevent machines in
 # one logical cluster from joining another.
-cluster_name: <%= p("cluster_name") %>
+cluster_name: <%= p("cluster_name").to_json %>
 
 # This defines the number of tokens randomly assigned to this node on the ring
 # The more tokens, relative to other nodes, the larger the proportion of data
@@ -22,7 +25,7 @@ cluster_name: <%= p("cluster_name") %>
 #
 # If you already have a cluster with 1 token per node, and wish to migrate to 
 # multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
-num_tokens: <%= p("num_tokens") %>
+num_tokens: <%= p("num_tokens").to_json %>
 
 # Triggers automatic allocation of num_tokens tokens for this node. The allocation
 # algorithm attempts to choose tokens in a way that optimizes replicated load over
@@ -43,7 +46,7 @@ num_tokens: <%= p("num_tokens") %>
 
 # See http://wiki.apache.org/cassandra/HintedHandoff
 # May either be "true" or "false" to enable globally
-hinted_handoff_enabled: <%= p("hinted_handoff_enabled") %>
+hinted_handoff_enabled: <%= p("hinted_handoff_enabled").to_json %>
 
 # When hinted_handoff_enabled is true, a black list of data centers that will not
 # perform hinted handoff
@@ -54,23 +57,23 @@ hinted_handoff_enabled: <%= p("hinted_handoff_enabled") %>
 # this defines the maximum amount of time a dead host will have hints
 # generated.  After it has been dead this long, new hints for it will not be
 # created until it has been seen alive and gone down again.
-max_hint_window_in_ms: <%= p("max_hint_window_in_ms") %>
+max_hint_window_in_ms: <%= p("max_hint_window_in_ms").to_json %>
 
 # Maximum throttle in KBs per second, per delivery thread.  This will be
 # reduced proportionally to the number of nodes in the cluster.  (If there
 # are two nodes in the cluster, each delivery thread will use the maximum
 # rate; if there are three, each will throttle to half of the maximum,
 # since we expect two nodes to be delivering hints simultaneously.)
-hinted_handoff_throttle_in_kb: <%= p("hinted_handoff_throttle_in_kb") %>
+hinted_handoff_throttle_in_kb: <%= p("hinted_handoff_throttle_in_kb").to_json %>
 
 # Number of threads with which to deliver hints;
 # Consider increasing this number when you have multi-dc deployments, since
 # cross-dc handoff tends to be slower
-max_hints_delivery_threads: <%= p("max_hints_delivery_threads") %>
+max_hints_delivery_threads: <%= p("max_hints_delivery_threads").to_json %>
 
 # Directory where Cassandra should store hints.
 # If not set, the default directory is $CASSANDRA_HOME/data/hints.
-hints_directory: /var/vcap/store/cassandra/<%= p("cluster_name") %>/hint
+hints_directory: <%= "/var/vcap/store/cassandra/#{p('cluster_name')}/hint".to_json %>
 
 # How often hints should be flushed from the internal buffers to disk.
 # Will *not* trigger fsync.
@@ -100,7 +103,7 @@ batchlog_replay_throttle_in_kb: 1024
 #   users. It keeps usernames and hashed passwords in system_auth.roles table.
 #   Please increase system_auth keyspace replication factor if you use this authenticator.
 #   If using PasswordAuthenticator, CassandraRoleManager must also be used (see below)
-authenticator: <%= p("authenticator") %>
+authenticator: <%= p("authenticator").to_json %>
 
 # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
 # Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
@@ -109,7 +112,7 @@ authenticator: <%= p("authenticator") %>
 # - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
 # - CassandraAuthorizer stores permissions in system_auth.role_permissions table. Please
 #   increase system_auth keyspace replication factor if you use this authorizer.
-authorizer: <%= p("authorizer") %>
+authorizer: <%= p("authorizer").to_json %>
 
 # Part of the Authentication & Authorization backend, implementing IRoleManager; used
 # to maintain grants and memberships between roles.
@@ -142,7 +145,7 @@ roles_validity_in_ms: <%= p("permissions_validity_in_ms").to_json %>
 # expensive operation depending on the authorizer, CassandraAuthorizer is
 # one example). Defaults to 2000, set to 0 to disable.
 # Will be disabled automatically for AllowAllAuthorizer.
-permissions_validity_in_ms: <%= p("permissions_validity_in_ms") %>
+permissions_validity_in_ms: <%= p("permissions_validity_in_ms").to_json %>
 
 # Refresh interval for permissions cache (if enabled).
 # After this interval, cache entries become eligible for refresh. Upon next
@@ -161,7 +164,7 @@ permissions_validity_in_ms: <%= p("permissions_validity_in_ms") %>
 # underlying table, it may not  bring a significant reduction in the
 # latency of individual authentication attempts.
 # Defaults to 2000, set to 0 to disable credentials caching.
-credentials_validity_in_ms: <%= p("credentials_validity_in_ms") %>
+credentials_validity_in_ms: <%= p("credentials_validity_in_ms").to_json %>
 
 # Refresh interval for credentials cache (if enabled).
 # After this interval, cache entries become eligible for refresh. Upon next
@@ -181,19 +184,19 @@ credentials_validity_in_ms: <%= p("credentials_validity_in_ms") %>
 # compatibility include RandomPartitioner, ByteOrderedPartitioner, and
 # OrderPreservingPartitioner.
 #
-partitioner: <%= p("partitioner") %>
+partitioner: <%= p("partitioner").to_json %>
 
 # Directories where Cassandra should store data on disk.  Cassandra
 # will spread data evenly across them, subject to the granularity of
 # the configured compaction strategy.
 # If not set, the default directory is $CASSANDRA_HOME/data/data.
 data_file_directories:
-    - /var/vcap/store/cassandra/<%= p("cluster_name") %>/data
+    - <%= "/var/vcap/store/cassandra/#{p('cluster_name')}/data".to_json %>
 
 # commit log.  when running on magnetic HDD, this should be a
 # separate spindle than the data directories.
 # If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
-commitlog_directory: /var/vcap/store/cassandra/<%= p("cluster_name") %>/commitlog
+commitlog_directory: <%= "/var/vcap/store/cassandra/#{p('cluster_name')}/commitlog".to_json %>
 
 # Enable / disable CDC functionality on a per-node basis. This modifies the logic used
 # for write path allocation rejection (standard: never reject. cdc: reject Mutation
@@ -227,7 +230,7 @@ cdc_enabled: false
 #
 # ignore
 #    ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
-disk_failure_policy: <%= p("disk_failure_policy") %>
+disk_failure_policy: <%= p("disk_failure_policy").to_json %>
 
 # Policy for commit disk failures:
 #
@@ -286,7 +289,7 @@ thrift_prepared_statements_cache_size_mb:
 # NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
 #
 # Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
-key_cache_size_in_mb: <%= p("key_cache_size_in_mb") %>
+key_cache_size_in_mb: <%= p("key_cache_size_in_mb").to_json %>
 
 # Duration in seconds after which Cassandra should
 # save the key cache. Caches are saved to saved_caches_directory as
@@ -297,7 +300,7 @@ key_cache_size_in_mb: <%= p("key_cache_size_in_mb") %>
 # has limited use.
 #
 # Default is 14400 or 4 hours.
-key_cache_save_period:  <%= p("key_cache_save_period") %>
+key_cache_save_period:  <%= p("key_cache_save_period").to_json %>
 
 # Number of keys from the key cache to save
 # Disabled by default, meaning all keys are going to be saved
@@ -321,7 +324,7 @@ key_cache_save_period:  <%= p("key_cache_save_period") %>
 # headroom for OS block level cache. Do never allow your system to swap.
 #
 # Default value is 0, to disable row caching.
-row_cache_size_in_mb: <%= p("row_cache_size_in_mb") %>
+row_cache_size_in_mb: <%= p("row_cache_size_in_mb").to_json %>
 
 # Duration in seconds after which Cassandra should save the row cache.
 # Caches are saved to saved_caches_directory as specified in this configuration file.
@@ -331,7 +334,7 @@ row_cache_size_in_mb: <%= p("row_cache_size_in_mb") %>
 # has limited use.
 #
 # Default is 0 to disable saving the row cache.
-row_cache_save_period: <%= p("row_cache_save_period") %>
+row_cache_save_period: <%= p("row_cache_save_period").to_json %>
 
 # Number of keys from the row cache to save.
 # Specify 0 (which is the default), meaning all keys are going to be saved
@@ -365,7 +368,7 @@ counter_cache_save_period: 7200
 
 # saved caches
 # If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
-saved_caches_directory: /var/vcap/store/cassandra/<%= p("cluster_name") %>/saved_caches
+saved_caches_directory: <%= "/var/vcap/store/cassandra/#{p('cluster_name')}/saved_caches".to_json %>
 
 # commitlog_sync may be either "periodic" or "batch." 
 # 
@@ -382,8 +385,8 @@ saved_caches_directory: /var/vcap/store/cassandra/<%= p("cluster_name") %>/saved
 # the other option is "periodic" where writes may be acked immediately
 # and the CommitLog is simply synced every commitlog_sync_period_in_ms
 # milliseconds. 
-commitlog_sync: <%= p("commitlog_sync") %>
-commitlog_sync_period_in_ms: <%= p("commitlog_sync_period_in_ms") %>
+commitlog_sync: <%= p("commitlog_sync").to_json %>
+commitlog_sync_period_in_ms: <%= p("commitlog_sync_period_in_ms").to_json %>
 
 # The size of the individual commitlog file segments.  A commitlog
 # segment may be archived, deleted, or recycled once all the data
@@ -401,7 +404,7 @@ commitlog_sync_period_in_ms: <%= p("commitlog_sync_period_in_ms") %>
 # NOTE: If max_mutation_size_in_kb is set explicitly then commitlog_segment_size_in_mb must
 # be set to at least twice the size of max_mutation_size_in_kb / 1024
 #
-commitlog_segment_size_in_mb: <%= p("commitlog_segment_size_in_mb") %>
+commitlog_segment_size_in_mb: <%= p("commitlog_segment_size_in_mb").to_json %>
 
 # Compression to apply to the commit log. If omitted, the commit log
 # will be written uncompressed.  LZ4, Snappy, and Deflate compressors
@@ -422,7 +425,7 @@ seed_provider:
       parameters:
           # seeds is actually a comma-delimited list of addresses.
           # Ex: "<ip1>,<ip2>,<ip3>"
-          - seeds: <% link('seeds').instances.each do |instance| %><%= instance.address %>,<% end %>
+          - seeds: <%= (link('seeds').instances.map { |instance| instance.address }).join(",").to_json %>
 
 # For workloads with more data than can fit in memory, Cassandra's
 # bottleneck will be reads that need to fetch data from
@@ -435,8 +438,8 @@ seed_provider:
 # On the other hand, since writes are almost never IO bound, the ideal
 # number of "concurrent_writes" is dependent on the number of cores in
 # your system; (8 * number_of_cores) is a good rule of thumb.
-concurrent_reads: <%= p("concurrent_reads") %>
-concurrent_writes: <%= p("concurrent_writes") %>
+concurrent_reads: <%= p("concurrent_reads").to_json %>
+concurrent_writes: <%= p("concurrent_writes").to_json %>
 concurrent_counter_writes: 32
 
 # For materialized view writes, as there is a read involved, so this should
@@ -451,7 +454,7 @@ concurrent_materialized_view_writes: 32
 # overhead which is roughly 128 bytes per chunk (i.e. 0.2% of the reserved size
 # if the default 64k chunk size is used).
 # Memory is only allocated when needed.
-file_cache_size_in_mb: <%= p("file_cache_size_in_mb") %>
+file_cache_size_in_mb: <%= p("file_cache_size_in_mb").to_json %>
 
 # Flag indicating whether to allocate on or off heap when the sstable buffer
 # pool is exhausted, that is when it has exceeded the maximum memory
@@ -536,7 +539,7 @@ memtable_allocation_type: heap_buffers
 # and flush size and frequency. More is not better you just need enough flush writers
 # to never stall waiting for flushing to free memory.
 #
-memtable_flush_writers: <%= p("memtable_flush_writers") %>
+memtable_flush_writers: <%= p("memtable_flush_writers").to_json %>
 
 # Total space to use for change-data-capture logs on disk.
 #
@@ -572,17 +575,17 @@ index_summary_resize_interval_in_minutes: 60
 # buffers. Enable this to avoid sudden dirty buffer flushing from
 # impacting read latencies. Almost always a good idea on SSDs; not
 # necessarily on platters.
-trickle_fsync: <%= p("trickle_fsync") %>
-trickle_fsync_interval_in_kb: <%= p("trickle_fsync_interval_in_kb") %>
+trickle_fsync: <%= p("trickle_fsync").to_json %>
+trickle_fsync_interval_in_kb: <%= p("trickle_fsync_interval_in_kb").to_json %>
 
 # TCP port, for commands and data
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-storage_port: <%= p("storage_port") %>
+storage_port: <%= p("storage_port").to_json %>
 
 # SSL port, for encrypted communication.  Unused unless enabled in
 # encryption_options
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-ssl_storage_port: <%= p("ssl_storage_port") %>
+ssl_storage_port: <%= p("ssl_storage_port").to_json %>
 
 # Address or interface to bind to and tell other Cassandra nodes to connect to.
 # You _must_ change this if you want multiple nodes to be able to communicate!
@@ -596,7 +599,7 @@ ssl_storage_port: <%= p("ssl_storage_port") %>
 #
 # Setting listen_address to 0.0.0.0 is always wrong.
 #
-listen_address: <%= spec.ip %>
+listen_address: <%= spec.ip.to_json %>
 
 # Set listen_address OR listen_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.
@@ -627,10 +630,10 @@ listen_address: <%= spec.ip %>
 # Whether to start the native transport server.
 # Please note that the address on which the native transport is bound is the
 # same as the rpc_address. The port however is different and specified below.
-start_native_transport: <%= p("start_native_transport") %>
+start_native_transport: <%= p("start_native_transport").to_json %>
 # port for the CQL native transport to listen for clients on
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-native_transport_port: <%= p("native_transport_port") %>
+native_transport_port: <%= p("native_transport_port").to_json %>
 # Enabling native transport encryption in client_encryption_options allows you to either use
 # encryption for the standard port or to use a dedicated, additional port along with the unencrypted
 # standard native_transport_port.
@@ -643,12 +646,12 @@ native_transport_port: <%= p("native_transport_port") %>
 # This is similar to rpc_max_threads though the default differs slightly (and
 # there is no native_transport_min_threads, idle threads will always be stopped
 # after 30 seconds).
-native_transport_max_threads: <%= p("native_transport_max_threads") %>
+native_transport_max_threads: <%= p("native_transport_max_threads").to_json %>
 #
 # The maximum size of allowed frame. Frame (requests) larger than this will
 # be rejected as invalid. The default is 256MB. If you're changing this parameter,
 # you may want to adjust max_value_size_in_mb accordingly. This should be positive and less than 2048.
-native_transport_max_frame_size_in_mb: <%= p("native_transport_max_frame_size_in_mb") %>
+native_transport_max_frame_size_in_mb: <%= p("native_transport_max_frame_size_in_mb").to_json %>
 
 # The maximum number of concurrent client connections.
 # The default is -1, which means unlimited.
@@ -659,7 +662,7 @@ native_transport_max_frame_size_in_mb: <%= p("native_transport_max_frame_size_in
 # native_transport_max_concurrent_connections_per_ip: -1
 
 # Whether to start the thrift rpc server.
-start_rpc: <%= p("start_rpc") %>
+start_rpc: <%= p("start_rpc").to_json %>
 
 # The address or interface to bind the Thrift RPC service and native transport
 # server to.
@@ -673,7 +676,7 @@ start_rpc: <%= p("start_rpc") %>
 # set broadcast_rpc_address to a value other than 0.0.0.0.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-rpc_address: <%= spec.ip %>
+rpc_address: <%= spec.ip.to_json %>
 
 # Set rpc_address OR rpc_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.
@@ -686,7 +689,7 @@ rpc_address: <%= spec.ip %>
 # rpc_interface_prefer_ipv6: false
 
 # port for Thrift to listen for clients on
-rpc_port: <%= p("rpc_port") %>
+rpc_port: <%= p("rpc_port").to_json %>
 
 # RPC address to broadcast to drivers and other Cassandra nodes. This cannot
 # be set to 0.0.0.0. If left blank, this will be set to the value of
@@ -695,7 +698,7 @@ rpc_port: <%= p("rpc_port") %>
 # broadcast_rpc_address: 1.2.3.4
 
 # enable or disable keepalive on rpc/native connections
-rpc_keepalive: <%= p("rpc_keepalive") %>
+rpc_keepalive: <%= p("rpc_keepalive").to_json %>
 
 # Cassandra provides two out-of-the-box options for the RPC Server:
 #
@@ -717,7 +720,7 @@ rpc_keepalive: <%= p("rpc_keepalive") %>
 #
 # Alternatively,  can provide your own RPC server by providing the fully-qualified class name
 # of an o.a.c.t.TServerFactory that can create an instance of it.
-rpc_server_type: <%= p("rpc_server_type") %>
+rpc_server_type: <%= p("rpc_server_type").to_json %>
 
 # Uncomment rpc_min|max_thread to set request pool size limits.
 #
@@ -729,8 +732,8 @@ rpc_server_type: <%= p("rpc_server_type") %>
 # encouraged to set a maximum that makes sense for you in production, but do keep in mind that
 # rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
 #
-rpc_min_threads: <%= p("rpc_min_threads") %>
-rpc_max_threads: <%= p("rpc_max_threads") %>
+rpc_min_threads: <%= p("rpc_min_threads").to_json %>
+rpc_max_threads: <%= p("rpc_max_threads").to_json %>
 
 # uncomment to set socket buffer sizes on rpc connections
 # rpc_send_buff_size_in_bytes:
@@ -753,25 +756,25 @@ rpc_max_threads: <%= p("rpc_max_threads") %>
 # internode_recv_buff_size_in_bytes:
 
 # Frame size for thrift (maximum message length).
-thrift_framed_transport_size_in_mb: <%= p("thrift_framed_transport_size_in_mb") %>
+thrift_framed_transport_size_in_mb: <%= p("thrift_framed_transport_size_in_mb").to_json %>
 
 # Set to true to have Cassandra create a hard link to each sstable
 # flushed or streamed locally in a backups/ subdirectory of the
 # keyspace data.  Removing these links is the operator's
 # responsibility.
-incremental_backups: <%= p("incremental_backups") %>
+incremental_backups: <%= p("incremental_backups").to_json %>
 
 # Whether or not to take a snapshot before each compaction.  Be
 # careful using this option, since Cassandra won't clean up the
 # snapshots for you.  Mostly useful if you're paranoid when there
 # is a data format change.
-snapshot_before_compaction: <%= p("snapshot_before_compaction") %>
+snapshot_before_compaction: <%= p("snapshot_before_compaction").to_json %>
 
 # Whether or not a snapshot is taken of the data before keyspace truncation
 # or dropping of column families. The STRONGLY advised default of true 
 # should be used to provide data safety. If you set this flag to false, you will
 # lose data on truncation or drop.
-auto_snapshot: <%= p("auto_snapshot") %>
+auto_snapshot: <%= p("auto_snapshot").to_json %>
 
 # Granularity of the collation index of rows within a partition.
 # Increase if your rows are large, or if you have a very large
@@ -783,7 +786,7 @@ auto_snapshot: <%= p("auto_snapshot") %>
 # - but, Cassandra will keep the collation index in memory for hot
 #   rows (as part of the key cache), so a larger granularity means
 #   you can cache more hot rows
-column_index_size_in_kb: <%= p("column_index_size_in_kb") %>
+column_index_size_in_kb: <%= p("column_index_size_in_kb").to_json %>
 
 # Per sstable indexed key cache entries (the collation index in memory
 # mentioned above) exceeding this size will not be held on heap.
@@ -808,7 +811,7 @@ column_index_cache_size_in_kb: 2
 # 
 # If your data directories are backed by SSD, you should increase this
 # to the number of cores.
-concurrent_compactors: <%= p("concurrent_compactors") %>
+concurrent_compactors: <%= p("concurrent_compactors").to_json %>
 
 # Throttles compaction to the given total throughput across the entire
 # system. The faster you insert data, the faster you need to compact in
@@ -839,22 +842,22 @@ sstable_preemptive_open_interval_in_mb: 50
 # inter_dc_stream_throughput_outbound_megabits_per_sec: 200
 
 # How long the coordinator should wait for read operations to complete
-read_request_timeout_in_ms: <%= p("read_request_timeout_in_ms") %>
+read_request_timeout_in_ms: <%= p("read_request_timeout_in_ms").to_json %>
 # How long the coordinator should wait for seq or index scans to complete
-range_request_timeout_in_ms: <%= p("range_request_timeout_in_ms") %>
+range_request_timeout_in_ms: <%= p("range_request_timeout_in_ms").to_json %>
 # How long the coordinator should wait for writes to complete
-write_request_timeout_in_ms: <%= p("write_request_timeout_in_ms") %>
+write_request_timeout_in_ms: <%= p("write_request_timeout_in_ms").to_json %>
 # How long the coordinator should wait for counter writes to complete
 counter_write_request_timeout_in_ms: 5000
 # How long a coordinator should continue to retry a CAS operation
 # that contends with other proposals for the same row
-cas_contention_timeout_in_ms: <%= p("cas_contention_timeout_in_ms") %>
+cas_contention_timeout_in_ms: <%= p("cas_contention_timeout_in_ms").to_json %>
 # How long the coordinator should wait for truncates to complete
 # (This can be much longer, because unless auto_snapshot is disabled
 # we need to flush first so we can snapshot before removing the data.)
-truncate_request_timeout_in_ms: <%= p("truncate_request_timeout_in_ms") %>
+truncate_request_timeout_in_ms: <%= p("truncate_request_timeout_in_ms").to_json %>
 # The default timeout for other, miscellaneous operations
-request_timeout_in_ms: <%= p("request_timeout_in_ms") %>
+request_timeout_in_ms: <%= p("request_timeout_in_ms").to_json %>
 
 # How long before a node logs slow queries. Select queries that take longer than
 # this timeout to execute, will generate an aggregated log message, so that slow queries
@@ -869,7 +872,7 @@ slow_query_log_timeout_in_ms: 500
 #
 # Warning: before enabling this property make sure to ntp is installed
 # and the times are synchronized between the nodes.
-cross_node_timeout: <%= p("cross_node_timeout") %>
+cross_node_timeout: <%= p("cross_node_timeout").to_json %>
 
 # Set keep-alive period for streaming
 # This node will send a keep-alive message periodically with this period.
@@ -881,7 +884,7 @@ cross_node_timeout: <%= p("cross_node_timeout") %>
 
 # phi value that must be reached for a host to be marked down.
 # most users should never need to adjust this.
-phi_convict_threshold: <%= p("phi_convict_threshold") %>
+phi_convict_threshold: <%= p("phi_convict_threshold").to_json %>
 
 # endpoint_snitch -- Set this to a class that implements
 # IEndpointSnitch.  The snitch has two functions:
@@ -946,14 +949,14 @@ phi_convict_threshold: <%= p("phi_convict_threshold") %>
 #
 # You can use a custom Snitch by setting this to the full class name
 # of the snitch, which will be assumed to be on your classpath.
-endpoint_snitch: <%= p("endpoint_snitch") %>
+endpoint_snitch: <%= p("endpoint_snitch").to_json %>
 
 # controls how often to perform the more expensive part of host score
 # calculation
-dynamic_snitch_update_interval_in_ms: <%= p("dynamic_snitch_update_interval_in_ms") %>
+dynamic_snitch_update_interval_in_ms: <%= p("dynamic_snitch_update_interval_in_ms").to_json %>
 # controls how often to reset all host scores, allowing a bad host to
 # possibly recover
-dynamic_snitch_reset_interval_in_ms: <%= p("dynamic_snitch_reset_interval_in_ms") %>
+dynamic_snitch_reset_interval_in_ms: <%= p("dynamic_snitch_reset_interval_in_ms").to_json %>
 # if set greater than zero and read_repair_chance is < 1.0, this will allow
 # 'pinning' of replicas to hosts in order to increase cache capacity.
 # The badness threshold will control how much worse the pinned host has to be
@@ -961,7 +964,7 @@ dynamic_snitch_reset_interval_in_ms: <%= p("dynamic_snitch_reset_interval_in_ms"
 # expressed as a double which represents a percentage.  Thus, a value of
 # 0.2 means Cassandra would continue to prefer the static snitch values
 # until the pinned host was 20% worse than the fastest.
-dynamic_snitch_badness_threshold: <%= p("dynamic_snitch_badness_threshold") %>
+dynamic_snitch_badness_threshold: <%= p("dynamic_snitch_badness_threshold").to_json %>
 
 # request_scheduler -- Set this to a class that implements
 # RequestScheduler, which will schedule incoming client requests
@@ -974,7 +977,7 @@ dynamic_snitch_badness_threshold: <%= p("dynamic_snitch_badness_threshold") %>
 # client requests to a node with a separate queue for each
 # request_scheduler_id. The scheduler is further customized by
 # request_scheduler_options as described below.
-request_scheduler: <%= p("request_scheduler") %>
+request_scheduler: <%= p("request_scheduler").to_json %>
 
 # Scheduler Options vary based on the type of scheduler
 #
@@ -1029,11 +1032,11 @@ request_scheduler: <%= p("request_scheduler") %>
 # http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
 #
 server_encryption_options:
-    internode_encryption: <%= p("internode_encryption_mode") %>
-    keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
-    keystore_password: <%= p("keystore_password") %>
-    truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
-    truststore_password: <%= p("keystore_password") %>
+    internode_encryption: <%= p("internode_encryption_mode").to_json %>
+    keystore: <%= "/var/vcap/jobs/cassandra/config/certs/#{spec.ip}_cassandra.keystore".to_json %>
+    keystore_password: <%= p("keystore_password").to_json %>
+    truststore: <%= "/var/vcap/jobs/cassandra/config/certs/#{spec.ip}_cassandra.truststore".to_json %>
+    truststore_password: <%= p("keystore_password").to_json %>
     protocol: TLS
     # More advanced defaults below:
     # protocol: TLS
@@ -1045,16 +1048,16 @@ server_encryption_options:
 
 # enable or disable client/server encryption.
 client_encryption_options:
-    enabled: <%= p("client_encryption.enabled") %>
+    enabled: <%= p("client_encryption.enabled").to_json %>
     # If enabled and optional is set to true encrypted and unencrypted connections are handled.
     optional: false
-    keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
-    keystore_password: <%= p("keystore_password") %>
+    keystore: <%= "/var/vcap/jobs/cassandra/config/certs/#{spec.ip}_cassandra.keystore".to_json %>
+    keystore_password: <%= p("keystore_password").to_json %>
 
-    require_client_auth: <%= p("client_encryption.require_client_auth") %>
+    require_client_auth: <%= p("client_encryption.require_client_auth").to_json %>
     # Set trustore and truststore_password if require_client_auth is true
-    truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
-    truststore_password: <%= p("keystore_password") %>
+    truststore: <%= "/var/vcap/jobs/cassandra/config/certs/#{spec.ip}_cassandra.truststore".to_json %>
+    truststore_password: <%= p("keystore_password").to_json %>
 
     # More advanced defaults below:
     protocol: TLS
@@ -1074,13 +1077,13 @@ client_encryption_options:
 #
 # none
 #   nothing is compressed.
-internode_compression: <%= p("internode_compression") %>
+internode_compression: <%= p("internode_compression").to_json %>
 
 # Enable or disable tcp_nodelay for inter-dc communication.
 # Disabling it will result in larger (but fewer) network packets being sent,
 # reducing overhead from the TCP protocol itself, at the cost of increasing
 # latency if you block for cross-datacenter responses.
-inter_dc_tcp_nodelay: <%= p("inter_dc_tcp_nodelay") %>
+inter_dc_tcp_nodelay: <%= p("inter_dc_tcp_nodelay").to_json %>
 
 # TTL for different trace types used during logging of the repair process.
 tracetype_query_ttl: 86400
@@ -1151,8 +1154,8 @@ transparent_data_encryption_options:
 # Adjust the thresholds here if you understand the dangers and want to
 # scan more tombstones anyway.  These thresholds may also be adjusted at runtime
 # using the StorageService mbean.
-tombstone_warn_threshold: <%= p("tombstone_warn_threshold") %>
-tombstone_failure_threshold: <%= p("tombstone_failure_threshold") %>
+tombstone_warn_threshold: <%= p("tombstone_warn_threshold").to_json %>
+tombstone_failure_threshold: <%= p("tombstone_failure_threshold").to_json %>
 
 # Log WARN on any multiple-partition batch size exceeding this value. 5kb per batch by default.
 # Caution should be taken on increasing the size of this threshold as it can lead to node instability.
@@ -1175,7 +1178,7 @@ gc_warn_threshold_in_ms: 1000
 # Maximum size of any value in SSTables. Safety measure to detect SSTable corruption
 # early. Any value size larger than this threshold will result into marking an SSTable
 # as corrupted. This should be positive and less than 2048.
-max_value_size_in_mb: <%= p("max_value_size_in_mb") %>
+max_value_size_in_mb: <%= p("max_value_size_in_mb").to_json %>
 
 # Back-pressure settings #
 # If enabled, the coordinator will apply the back-pressure strategy specified below to each mutation

--- a/jobs/cassandra/templates/config/jvm.options.erb
+++ b/jobs/cassandra/templates/config/jvm.options.erb
@@ -7,6 +7,13 @@
 # - only static flags are accepted (no variables or parameters)           #
 # - dynamic flags will be appended to these on cassandra-env              #
 ###########################################################################
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+-%>
 
 ######################
 # STARTUP PARAMETERS #
@@ -254,5 +261,5 @@
 -Djava.io.tmpdir=/var/vcap/data/cassandra/jna-tmp
 
 <% if p('jmx_exporter_enabled') %>
--javaagent:/var/vcap/packages/cassandra/lib/jmx_prometheus_javaagent-0.1.0.jar=<%= p('jmx_exporter_port') %>:/var/vcap/jobs/cassandra/conf/jmx_exporter.yml
+-javaagent:/var/vcap/packages/cassandra/lib/jmx_prometheus_javaagent-0.1.0.jar=<%= esc(p('jmx_exporter_port')) %>:/var/vcap/jobs/cassandra/conf/jmx_exporter.yml
 <% end %>


### PR DESCRIPTION
In this PR, we suggest the following improvements:

- Implement proper escaping when injecting ERB values in Bash scripts or YAML files
- Have the `system_auth_keyspace_replication_factor` property default to the number of seed nodes in the cluster when unspecified
- Remove the erroneous and duplicate `-Xloggc` in cassandra invocation
