### PR TITLE
[to merge 2nd] Review config props

### DIFF
--- a/deployment/cassandra.yml
+++ b/deployment/cassandra.yml
@@ -3,7 +3,7 @@ name: cassandra
 
 instance_groups:
   - name: cassandra-seeds
-    instances: &cassandra_seeds_count 3
+    instances: 3
     azs: [ z1, z2, z3 ]
     jobs:
       - name: cassandra
@@ -13,7 +13,6 @@ instance_groups:
         consumes:
           seeds: { from: *cassandra_seeds_link }
         properties: &cassandra_properties
-          system_auth_keyspace_replication_factor: *cassandra_seeds_count
           cluster_name: &cassandra_cluster_name cluster
           num_tokens: 256
           internode_encryption_mode: none

--- a/jobs/broker/templates/config/application.yml.erb
+++ b/jobs/broker/templates/config/application.yml.erb
@@ -17,7 +17,7 @@ spring:
     show-banner: true
   data:
     cassandra:
-      password: <%= link('seeds').p('cass_pwd') %>
+      password: <%= link('seeds').p('cassandra_password') %>
       contact-points: <% link('seeds').instances.each do |instance| %><%= instance.address %>,<% end %>
       single-contact-points: <%= link('seeds').instances[0].address %>
       username: cassandra

--- a/jobs/cassandra-admin-tools/templates/bin/ops-admin/operation-tool.sh
+++ b/jobs/cassandra-admin-tools/templates/bin/ops-admin/operation-tool.sh
@@ -7,7 +7,7 @@ NODE=''
 OPERATION=''
 PID=''
 USER="$(whoami)"
-export CASS_PWD="<%= link('seeds').p('cass_pwd') %>"
+export CASS_PWD="<%= link('seeds').p('cassandra_password') %>"
 
 backup_data() {
     check_process

--- a/jobs/cassandra-admin-tools/templates/bin/sstable-loader.sh
+++ b/jobs/cassandra-admin-tools/templates/bin/sstable-loader.sh
@@ -11,7 +11,7 @@ export CASSANDRA_TOOL=/var/vcap/packages/cassandra/tools/bin
 
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:/var/vcap/packages/openjdk/bin:$CASSANDRA_BIN:$CASSANDRA_CONF:$CASSANDRA_TOOL
-export CASS_PWD="<%= link('seeds').p('cass_pwd') %>"
+export CASS_PWD="<%= link('seeds').p('cassandra_password') %>"
 
 pushd /var/vcap/packages/cassandra/tools/bin
 if [ $# -eq 0 ];

--- a/jobs/cassandra-admin-tools/templates/config/cqlshrc.erb
+++ b/jobs/cassandra-admin-tools/templates/config/cqlshrc.erb
@@ -1,6 +1,6 @@
 [authentication]
 username = cassandra
-password = <%= link("seeds").p("cass_pwd") %>
+password = <%= link("seeds").p("cassandra_password") %>
 ;;keyspace =
 
 

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -780,7 +780,11 @@ properties:
     description: |
       The replication factor to apply to the 'system_auth' keyspace that holds
       users and passwords.
-    default: 3
+
+      When this value is nor defined or 'null', the default replication factor
+      used is the number of seeds instances, as can be inferred when
+      traversing the 'seeds' Bosh Link.
+    default: null
 
   disable_linux_swap:
     description: |

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -137,13 +137,34 @@ properties:
         'system_auth_keyspace_replication_factor' to 1 results in denial of
         access to the cluster if the single replica of the keyspace goes down.
     default: CassandraAuthorizer
+  roles_validity_in_ms:
+    description: |
+      Fetching permissions can be an expensive operation depending on the
+      authorizer, so this setting allows flexibility. Validity period for
+      roles cache; set to '0' to disable. Granted roles are cached for
+      authenticated sessions in 'AuthenticatedUser' and after the period
+      specified here, become eligible for (async) reload. Disabled
+      automatically for 'AllowAllAuthenticator'.
+    default: 2000
   permissions_validity_in_ms:
     description: |
       How many milliseconds permissions in cache remain valid. Depending on
       the authorizer, such as 'CassandraAuthorizer', fetching permissions can
       be resource intensive. This setting is disabled when set to 0 or when
       'authorizer' is set to 'AllowAllAuthorizer'.
-    default: 4000
+    default: 2000
+  credentials_validity_in_ms:
+    description: |
+      How many milliseconds credentials in the cache remain valid. This cache
+      is tightly coupled to the provided 'PasswordAuthenticator'
+      implementation of 'IAuthenticator'. If another 'IAuthenticator'
+      implementation is configured, Cassandra does not use this cache, and
+      these settings have no effect. Set to '0' to disable.
+
+        Note: Credentials are cached in encrypted form. This may cause a
+        performance penalty that offsets the reduction in latency gained by
+        caching.
+    default: 2000
   partitioner:
     description: |
       Sets the class that distributes rows (by partition key) across all nodes

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -204,10 +204,12 @@ properties:
   key_cache_size_in_mb:
     description: |
       A global cache setting for the maximum size of the key cache in memory
-      (for all tables). If an empty string or a 'null' value is set, the cache
-      is set to the smaller of 5% of the available heap (when heap size is
-      above 2GB), or 100MB. To disable set to 0.
-    default: 100
+      (for all tables). To disable set to '0'.
+
+      If an empty string or a 'null' value is set, the cache is set to the
+      smaller of 5% of the available heap (when heap size is below 2GB), or
+      100MB.
+    default: null # min(5% of heap, 100MB)
   key_cache_save_period:
     description: |
       Duration in seconds that keys are kept in cache. Saved caches greatly
@@ -228,7 +230,6 @@ properties:
     default: 0
   commitlog_sync:
     description: |
-
       The method that Cassandra uses to acknowledge writes in milliseconds:
 
       - periodic: (Default: 10000 milliseconds [10 seconds])
@@ -240,8 +241,11 @@ properties:
         is the maximum length of time that queries may be batched together.
     default: periodic
   commitlog_sync_period_in_ms:
-    default: 2
-    description: temps d attente d autres ecritures par cassandra avant de faire un sync. Utiliser si option batch activee. Acquittement retarde au sync.
+    description: |
+      When 'commitlog_sync' is set to 'periodic', this controls how often the
+      commit log is synchronized to disk. Periodic syncs are acknowledged
+      immediately.
+    default: 10000
   commitlog_segment_size_in_mb:
     description: |
       The size of an individual commitlog file segment. A commitlog segment
@@ -260,7 +264,7 @@ properties:
       (16 × number_of_drives) allows operations to queue low enough in the
       stack so that the OS and drives can reorder them. The default setting
       applies to both logical volume managed (LVM) and RAID drives.
-    default: 32
+    default: 16
   concurrent_writes:
     description: |
       Writes in Cassandra are rarely I/O bound, so the ideal number of
@@ -269,9 +273,14 @@ properties:
     default: 32
   file_cache_size_in_mb:
     description: |
-      Total memory to use for SSTable-reading buffers. Defaults to the smaller
-      of 1/4 of heap (when heap is less than 2GB) or 512MB.
-    default: 512
+      Total memory to use for SSTable-reading buffers.
+
+      32MB of this are reserved for pooling buffers, the rest is used as a
+      cache that holds uncompressed sstable chunks.
+
+      When set to 'null' or not defined, this value defaults to the smaller of
+      1/4 of heap (when heap is less than 2GB) or 512MB.
+    default: null # Smaller of 1/4 heap or 512
   memtable_flush_writers:
     description: |
       The number of memtable flush writer threads. These threads are blocked
@@ -279,9 +288,11 @@ properties:
       your data directories are backed by SSDs, increase this setting to the
       number of cores.
 
-      (Default: Smaller of number of disks or number of cores with a minimum
-      of 2 and a maximum of 8)
-    default: 1
+      When set to 'null' or not defined, this value defaults to the smaller of
+      number_of_disks or number_of_cores with a minimum of 2 and a maximum of
+      8. Using this BOSH Release, Cassandra nodes always have one disk, so
+      this calculation should always result in a value of '2'.
+    default: null # min(8, max(2, min(number_of_disks, number_of_cores)))
   trickle_fsync:
     description: |
       When set to 'true', causes fsync to force the operating system to flush
@@ -438,7 +449,13 @@ properties:
       disk space for compaction, because concurrent compactions happen in
       parallel, especially for STCS. Ensure that adequate disk space is
       available before increasing this configuration.
-    default: 4
+
+      If set to 'null' or not defined, this value defaults to the smaller of
+      number_of_disks or number_of_cores, with a minimum of 2 and a maximum of
+      8 per CPU core. Using this BOSH Release, Cassandra nodes always have one
+      disk, so this calculation should always result in a value of '2'.
+    default: null # min(8 × number_of_cores, max(2, min(number_of_disks, number_of_cores)))
+    example: 8 # the number of CPU core, when using SSDs
   read_request_timeout_in_ms:
     description: |
       The number of milliseconds that the coordinator waits for read
@@ -490,6 +507,14 @@ properties:
     description: |
       Adjusts the sensitivity of the failure detector on an exponential scale.
       Generally this setting does not need adjusting.
+
+      Use the default value for most situations, but increase it to 10 or 12
+      for Amazon EC2 (due to frequently encountered network congestion). In
+      unstable network environments (such as EC2 at times), raising the value
+      to 10 or 12 helps prevent false failures. Values higher than 12 and
+      lower than 5 are not recommended.
+
+      See also: <https://docs.datastax.com/en/cassandra/latest/cassandra/architecture/archDataDistributeFailDetect.html>
     default: 8
   endpoint_snitch:
     description: |
@@ -636,7 +661,7 @@ properties:
   cert:
     type: certificate
     description: |
-      Cluster certificate.
+      Cluster certificate, as can be provided by CredHub.
     example:
       ca: |
         -----BEGIN CERTIFICATE-----
@@ -663,7 +688,7 @@ properties:
 
       - 'none'
         No compression.
-    default: none
+    default: dc
   inter_dc_tcp_nodelay:
     description: |
       Enable this property or 'disable tcp_nodelay' for inter-datacenter
@@ -671,7 +696,7 @@ properties:
       but fewer, network packets. This reduces overhead from the TCP protocol
       itself. However, disabling 'inter_dc_tcp_nodelay' may increase latency
       by blocking cross data-center responses.
-    default: true
+    default: false
 
   tombstone_warn_threshold:
     description: |
@@ -745,9 +770,10 @@ properties:
     default: cassandra
   validate_ssl_TF:
     description: |
-      When validate is enabled, the cqlsh clients will verify that the
-      certificate is trusted. The host in the certificate is compared to the
-      host of the machine to which it is connected.
+      When validate is enabled, the locally installed cqlsh clients will
+      verify that the certificate is trusted, and the host in the certificate
+      will be compared to the host of the machine to which the clients are
+      connected.
     default: false
 
   system_auth_keyspace_replication_factor:

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -684,20 +684,25 @@ properties:
     description: |
       The total amount of memory dedicated to the Java heap.
 
-      The default max heap size is based on the following calculation:
+      When both 'max_heap_size' and 'heap_newsize' are set to an empty string
+      value (""), then the default max heap size is based on the following
+      calculation:
 
-        max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
+        max(min(1/2 ram, 1GB), min(1/4 ram, 8GB))
 
       Which can be described by this algorithm:
         1. calculate 1/2 ram and cap to 1024MB
         2. calculate 1/4 ram and cap to 8192MB
         3. pick the max
-    default: 8G
+    default: "" # max(min(1/2 ram, 1GB), min(1/4 ram, 8GB))
+    example: 8G
   heap_newsize:
     description: |
       Size of the young generation.
 
-      The default young generation size is computed as folows:
+      When both 'max_heap_size' and 'heap_newsize' are set to an empty string
+      value (""), then the default young generation size is computed as
+      folows:
 
         min(max_sensible_per_modern_cpu_core * num_cores, 1/4 * heap size)
 
@@ -712,7 +717,8 @@ properties:
       The main trade-off for the young generation is that the larger it is,
       the longer GC pause times will be. The shorter it is, the more expensive
       GC will be (usually).
-    default: 1G
+    default: "" # min(max_sensible_per_modern_cpu_core * num_cores, 1/4 * heap size)
+    example: 1G
   cass_pwd:
     default: cassandra
   validate_ssl_TF:

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -697,6 +697,15 @@ properties:
       Cassandra aborts a query if it scans more than this number of
       tombstones.
     default: 100000
+  max_value_size_in_mb:
+    description: |
+      The maximum size of any value in SSTables.
+
+      Any value size larger than this threshold will result into marking an
+      SSTable as corrupted.
+
+      This should be positive and less than 2048.
+    default: 256
 
   max_heap_size:
     description: |

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -9,7 +9,7 @@ provides:
   - name: cassandra
     type: cassandra
     properties:
-      - cass_pwd
+      - cassandra_password
       - native_transport_port
       - client_encryption.enabled
       - validate_ssl_TF
@@ -719,7 +719,16 @@ properties:
       GC will be (usually).
     default: "" # min(max_sensible_per_modern_cpu_core * num_cores, 1/4 * heap size)
     example: 1G
-  cass_pwd:
+  cassandra_password:
+    description: |
+      This is the password for the default 'cassandra' admin user.
+
+      By default, the Cassandra daemon uses 'cassandra' as the password for
+      this user and this value is hardcoded in Cassandra code, so we
+      shamelessly use this as the default here.
+
+      For security reasons, you are highly recommended to use a strong
+      password here for production systems.
     default: cassandra
   validate_ssl_TF:
     description: |

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -38,8 +38,6 @@ templates:
   config/logback-tools.xml.erb: conf/logback-tools.xml
   config/commitlog_archiving.properties.erb: conf/commitlog_archiving.properties
 #  bin/generate_ssl_cert.sh: bin/generate_ssl_cert.sh
-#  ssl/cassandradb.ca.erb: ssl/cassandradb.ca
-#  ssl/cassandradb.pem.erb: ssl/cassandradb.pem
 #  ssl2/cert: config/certs/node.crt
 #  ssl2/cert_ca: config/certs/ca.crt
 #  ssl2/cert_private_key: config/certs/node.key
@@ -635,18 +633,6 @@ properties:
     description: |
       Password for the keystore that is used to to store server and client
       encryption certificates and keys.
-  cassDbCertificate:
-    type: certificate
-    description: |
-      use tls/ssl for authent and transactions.
-
-      Structured certificate as can be provided by CredHub.
-
-      Injected in:
-      - .ca: ssl/cassandradb.ca.erb (deprecated)
-      - .certificate and .private_key: cassandradb.pem.erb (deprecated)
-
-    default: "NOT INITIALIZED"
   cert:
     type: certificate
     description: |

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -156,9 +156,6 @@ properties:
       - ByteOrderedPartitioner (deprecated)
       - OrderPreservingPartitioner (deprecated)
     default: org.apache.cassandra.dht.Murmur3Partitioner
-  persistent_directory:
-    default: /var/vcap/store/cassandra
-    description: point racine de l arborescence Cassandra pour stocker tous les fichiers data, commit log et saved_cache
   disk_failure_policy:
     description: |
       Sets how Cassandra responds to disk failure. Recommend settings: 'stop'

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -613,7 +613,7 @@ properties:
     default: false
     description: |
       Enables or disables certificate authentication.
-  cass_KSP:
+  keystore_password:
     description: |
       Password for the keystore that is used to to store server and client
       encryption certificates and keys.

--- a/jobs/cassandra/templates/bin/cassandra_ctl
+++ b/jobs/cassandra/templates/bin/cassandra_ctl
@@ -20,6 +20,7 @@ export CASSANDRA_CONF=/var/vcap/jobs/cassandra/conf
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:/var/vcap/packages/openjdk/bin
 
+export CASSANDRA_HEAPDUMP_DIR=/var/vcap/data/cassandra
 
 case $1 in
 

--- a/jobs/cassandra/templates/bin/post-start.sh
+++ b/jobs/cassandra/templates/bin/post-start.sh
@@ -70,12 +70,17 @@ fi
 
 
 log_err "INFO: setting replication strategy for cassandra password"
+<%
+  require "json"
+
+  replication_factor = p('system_auth_keyspace_replication_factor', link('seeds').instances.count)
+-%>
 # Note: should we support multiple datacenters one day, then we should set the
 # replication class to 'NetworkTopologyStrategy' here instead of 'SimpleStrategy'.
 # See: <https://docs.datastax.com/en/cassandra/latest/cassandra/configuration/configCassandra_yaml.html#configCassandra_yaml__authenticator>
 # See: <https://docs.datastax.com/en/cassandra/latest/cassandra/configuration/configCassandra_yaml.html#configCassandra_yaml__authorizer>
 $CASSANDRA_BIN/cqlsh --cqlshrc "$job_dir/root/.cassandra/cqlshrc" \
-     -e "alter keyspace system_auth WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '<%= p('system_auth_keyspace_replication_factor') %>'}  AND durable_writes = true"
+     -e 'alter keyspace system_auth WITH replication = {"class": "SimpleStrategy", "replication_factor": <%= replication_factor.to_json %>}  AND durable_writes = true'
 
 log_err "INFO: propagating any new password with the enforced replication strategy"
 $job_dir/bin/nodetool repair system_auth

--- a/jobs/cassandra/templates/bin/post-start.sh
+++ b/jobs/cassandra/templates/bin/post-start.sh
@@ -21,7 +21,7 @@ export CASSANDRA_CONF=$job_dir/conf
 export JAVA_HOME=/var/vcap/packages/openjdk
 export PATH=$PATH:$JAVA_HOME/bin:$CASSANDRA_BIN
 
-cass_pwd=<%= esc(p('cass_pwd')) %>
+cass_pwd=<%= esc(p('cassandra_password')) %>
 
 
 function log_err() {

--- a/jobs/cassandra/templates/bpm.yml
+++ b/jobs/cassandra/templates/bpm.yml
@@ -9,6 +9,7 @@ processes:
       CASSANDRA_CONF: /var/vcap/jobs/cassandra/conf
       JAVA_HOME: /var/vcap/packages/openjdk
       # HOME: /var/vcap/data/cassandra/home
+      CASSANDRA_HEAPDUMP_DIR: /var/vcap/data/cassandra
     limits:
       # Set limits as recommended
       # See: <https://docs.datastax.com/en/dse/5.1/dse-dev/datastax_enterprise/config/configRecommendedSettings.html>

--- a/jobs/cassandra/templates/config/cassandra-env.sh.erb
+++ b/jobs/cassandra/templates/config/cassandra-env.sh.erb
@@ -13,6 +13,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+-%>
 
 calculate_heap_sizes()
 {
@@ -122,7 +129,7 @@ case "$jvm" in
 esac
 
 #GC log path has to be defined here because it needs to access CASSANDRA_HOME
-JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
+#JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
 
 # Here we create the arguments that will get passed to the jvm when
 # starting cassandra.
@@ -161,8 +168,8 @@ USING_G1=$?
 # times. If in doubt, and if you do not particularly want to tweak, go with
 # 100 MB per physical CPU core.
 
-MAX_HEAP_SIZE="<%= p("max_heap_size") %>"
-HEAP_NEWSIZE="<%= p("heap_newsize") %>"
+MAX_HEAP_SIZE=<%= esc(p("max_heap_size")) %>
+HEAP_NEWSIZE=<%= esc(p("heap_newsize")) %>
 
 # Set this to control the amount of arenas per-thread in glibc
 #export MALLOC_ARENA_MAX=4

--- a/jobs/cassandra/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra/templates/config/cassandra.yaml.erb
@@ -1,4 +1,7 @@
 # Cassandra storage config YAML
+<%
+  require "json"
+-%>
 
 # NOTE:
 #   See http://wiki.apache.org/cassandra/StorageConfiguration for
@@ -7,7 +10,7 @@
 
 # The name of the cluster. This is mainly used to prevent machines in
 # one logical cluster from joining another.
-cluster_name: <%= p("cluster_name") %>
+cluster_name: <%= p("cluster_name").to_json %>
 
 # This defines the number of tokens randomly assigned to this node on the ring
 # The more tokens, relative to other nodes, the larger the proportion of data
@@ -22,7 +25,7 @@ cluster_name: <%= p("cluster_name") %>
 #
 # If you already have a cluster with 1 token per node, and wish to migrate to 
 # multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
-num_tokens: <%= p("num_tokens") %>
+num_tokens: <%= p("num_tokens").to_json %>
 
 # Triggers automatic allocation of num_tokens tokens for this node. The allocation
 # algorithm attempts to choose tokens in a way that optimizes replicated load over
@@ -43,7 +46,7 @@ num_tokens: <%= p("num_tokens") %>
 
 # See http://wiki.apache.org/cassandra/HintedHandoff
 # May either be "true" or "false" to enable globally
-hinted_handoff_enabled: <%= p("hinted_handoff_enabled") %>
+hinted_handoff_enabled: <%= p("hinted_handoff_enabled").to_json %>
 
 # When hinted_handoff_enabled is true, a black list of data centers that will not
 # perform hinted handoff
@@ -54,23 +57,23 @@ hinted_handoff_enabled: <%= p("hinted_handoff_enabled") %>
 # this defines the maximum amount of time a dead host will have hints
 # generated.  After it has been dead this long, new hints for it will not be
 # created until it has been seen alive and gone down again.
-max_hint_window_in_ms: <%= p("max_hint_window_in_ms") %>
+max_hint_window_in_ms: <%= p("max_hint_window_in_ms").to_json %>
 
 # Maximum throttle in KBs per second, per delivery thread.  This will be
 # reduced proportionally to the number of nodes in the cluster.  (If there
 # are two nodes in the cluster, each delivery thread will use the maximum
 # rate; if there are three, each will throttle to half of the maximum,
 # since we expect two nodes to be delivering hints simultaneously.)
-hinted_handoff_throttle_in_kb: <%= p("hinted_handoff_throttle_in_kb") %>
+hinted_handoff_throttle_in_kb: <%= p("hinted_handoff_throttle_in_kb").to_json %>
 
 # Number of threads with which to deliver hints;
 # Consider increasing this number when you have multi-dc deployments, since
 # cross-dc handoff tends to be slower
-max_hints_delivery_threads: <%= p("max_hints_delivery_threads") %>
+max_hints_delivery_threads: <%= p("max_hints_delivery_threads").to_json %>
 
 # Directory where Cassandra should store hints.
 # If not set, the default directory is $CASSANDRA_HOME/data/hints.
-hints_directory: /var/vcap/store/cassandra/<%= p("cluster_name") %>/hint
+hints_directory: <%= "/var/vcap/store/cassandra/#{p('cluster_name')}/hint".to_json %>
 
 # How often hints should be flushed from the internal buffers to disk.
 # Will *not* trigger fsync.
@@ -100,7 +103,7 @@ batchlog_replay_throttle_in_kb: 1024
 #   users. It keeps usernames and hashed passwords in system_auth.roles table.
 #   Please increase system_auth keyspace replication factor if you use this authenticator.
 #   If using PasswordAuthenticator, CassandraRoleManager must also be used (see below)
-authenticator: <%= p("authenticator") %>
+authenticator: <%= p("authenticator").to_json %>
 
 # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
 # Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
@@ -109,7 +112,7 @@ authenticator: <%= p("authenticator") %>
 # - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
 # - CassandraAuthorizer stores permissions in system_auth.role_permissions table. Please
 #   increase system_auth keyspace replication factor if you use this authorizer.
-authorizer: <%= p("authorizer") %>
+authorizer: <%= p("authorizer").to_json %>
 
 # Part of the Authentication & Authorization backend, implementing IRoleManager; used
 # to maintain grants and memberships between roles.
@@ -142,7 +145,7 @@ roles_validity_in_ms: <%= p("permissions_validity_in_ms").to_json %>
 # expensive operation depending on the authorizer, CassandraAuthorizer is
 # one example). Defaults to 2000, set to 0 to disable.
 # Will be disabled automatically for AllowAllAuthorizer.
-permissions_validity_in_ms: <%= p("permissions_validity_in_ms") %>
+permissions_validity_in_ms: <%= p("permissions_validity_in_ms").to_json %>
 
 # Refresh interval for permissions cache (if enabled).
 # After this interval, cache entries become eligible for refresh. Upon next
@@ -161,7 +164,7 @@ permissions_validity_in_ms: <%= p("permissions_validity_in_ms") %>
 # underlying table, it may not  bring a significant reduction in the
 # latency of individual authentication attempts.
 # Defaults to 2000, set to 0 to disable credentials caching.
-credentials_validity_in_ms: <%= p("credentials_validity_in_ms") %>
+credentials_validity_in_ms: <%= p("credentials_validity_in_ms").to_json %>
 
 # Refresh interval for credentials cache (if enabled).
 # After this interval, cache entries become eligible for refresh. Upon next
@@ -181,19 +184,19 @@ credentials_validity_in_ms: <%= p("credentials_validity_in_ms") %>
 # compatibility include RandomPartitioner, ByteOrderedPartitioner, and
 # OrderPreservingPartitioner.
 #
-partitioner: <%= p("partitioner") %>
+partitioner: <%= p("partitioner").to_json %>
 
 # Directories where Cassandra should store data on disk.  Cassandra
 # will spread data evenly across them, subject to the granularity of
 # the configured compaction strategy.
 # If not set, the default directory is $CASSANDRA_HOME/data/data.
 data_file_directories:
-    - /var/vcap/store/cassandra/<%= p("cluster_name") %>/data
+    - <%= "/var/vcap/store/cassandra/#{p('cluster_name')}/data".to_json %>
 
 # commit log.  when running on magnetic HDD, this should be a
 # separate spindle than the data directories.
 # If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
-commitlog_directory: /var/vcap/store/cassandra/<%= p("cluster_name") %>/commitlog
+commitlog_directory: <%= "/var/vcap/store/cassandra/#{p('cluster_name')}/commitlog".to_json %>
 
 # Enable / disable CDC functionality on a per-node basis. This modifies the logic used
 # for write path allocation rejection (standard: never reject. cdc: reject Mutation
@@ -227,7 +230,7 @@ cdc_enabled: false
 #
 # ignore
 #    ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
-disk_failure_policy: <%= p("disk_failure_policy") %>
+disk_failure_policy: <%= p("disk_failure_policy").to_json %>
 
 # Policy for commit disk failures:
 #
@@ -286,7 +289,7 @@ thrift_prepared_statements_cache_size_mb:
 # NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
 #
 # Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
-key_cache_size_in_mb: <%= p("key_cache_size_in_mb") %>
+key_cache_size_in_mb: <%= p("key_cache_size_in_mb").to_json %>
 
 # Duration in seconds after which Cassandra should
 # save the key cache. Caches are saved to saved_caches_directory as
@@ -297,7 +300,7 @@ key_cache_size_in_mb: <%= p("key_cache_size_in_mb") %>
 # has limited use.
 #
 # Default is 14400 or 4 hours.
-key_cache_save_period:  <%= p("key_cache_save_period") %>
+key_cache_save_period:  <%= p("key_cache_save_period").to_json %>
 
 # Number of keys from the key cache to save
 # Disabled by default, meaning all keys are going to be saved
@@ -321,7 +324,7 @@ key_cache_save_period:  <%= p("key_cache_save_period") %>
 # headroom for OS block level cache. Do never allow your system to swap.
 #
 # Default value is 0, to disable row caching.
-row_cache_size_in_mb: <%= p("row_cache_size_in_mb") %>
+row_cache_size_in_mb: <%= p("row_cache_size_in_mb").to_json %>
 
 # Duration in seconds after which Cassandra should save the row cache.
 # Caches are saved to saved_caches_directory as specified in this configuration file.
@@ -331,7 +334,7 @@ row_cache_size_in_mb: <%= p("row_cache_size_in_mb") %>
 # has limited use.
 #
 # Default is 0 to disable saving the row cache.
-row_cache_save_period: <%= p("row_cache_save_period") %>
+row_cache_save_period: <%= p("row_cache_save_period").to_json %>
 
 # Number of keys from the row cache to save.
 # Specify 0 (which is the default), meaning all keys are going to be saved
@@ -365,7 +368,7 @@ counter_cache_save_period: 7200
 
 # saved caches
 # If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
-saved_caches_directory: /var/vcap/store/cassandra/<%= p("cluster_name") %>/saved_caches
+saved_caches_directory: <%= "/var/vcap/store/cassandra/#{p('cluster_name')}/saved_caches".to_json %>
 
 # commitlog_sync may be either "periodic" or "batch." 
 # 
@@ -382,8 +385,8 @@ saved_caches_directory: /var/vcap/store/cassandra/<%= p("cluster_name") %>/saved
 # the other option is "periodic" where writes may be acked immediately
 # and the CommitLog is simply synced every commitlog_sync_period_in_ms
 # milliseconds. 
-commitlog_sync: <%= p("commitlog_sync") %>
-commitlog_sync_period_in_ms: <%= p("commitlog_sync_period_in_ms") %>
+commitlog_sync: <%= p("commitlog_sync").to_json %>
+commitlog_sync_period_in_ms: <%= p("commitlog_sync_period_in_ms").to_json %>
 
 # The size of the individual commitlog file segments.  A commitlog
 # segment may be archived, deleted, or recycled once all the data
@@ -401,7 +404,7 @@ commitlog_sync_period_in_ms: <%= p("commitlog_sync_period_in_ms") %>
 # NOTE: If max_mutation_size_in_kb is set explicitly then commitlog_segment_size_in_mb must
 # be set to at least twice the size of max_mutation_size_in_kb / 1024
 #
-commitlog_segment_size_in_mb: <%= p("commitlog_segment_size_in_mb") %>
+commitlog_segment_size_in_mb: <%= p("commitlog_segment_size_in_mb").to_json %>
 
 # Compression to apply to the commit log. If omitted, the commit log
 # will be written uncompressed.  LZ4, Snappy, and Deflate compressors
@@ -422,7 +425,7 @@ seed_provider:
       parameters:
           # seeds is actually a comma-delimited list of addresses.
           # Ex: "<ip1>,<ip2>,<ip3>"
-          - seeds: <% link('seeds').instances.each do |instance| %><%= instance.address %>,<% end %>
+          - seeds: <%= (link('seeds').instances.map { |instance| instance.address }).join(",").to_json %>
 
 # For workloads with more data than can fit in memory, Cassandra's
 # bottleneck will be reads that need to fetch data from
@@ -435,8 +438,8 @@ seed_provider:
 # On the other hand, since writes are almost never IO bound, the ideal
 # number of "concurrent_writes" is dependent on the number of cores in
 # your system; (8 * number_of_cores) is a good rule of thumb.
-concurrent_reads: <%= p("concurrent_reads") %>
-concurrent_writes: <%= p("concurrent_writes") %>
+concurrent_reads: <%= p("concurrent_reads").to_json %>
+concurrent_writes: <%= p("concurrent_writes").to_json %>
 concurrent_counter_writes: 32
 
 # For materialized view writes, as there is a read involved, so this should
@@ -451,7 +454,7 @@ concurrent_materialized_view_writes: 32
 # overhead which is roughly 128 bytes per chunk (i.e. 0.2% of the reserved size
 # if the default 64k chunk size is used).
 # Memory is only allocated when needed.
-file_cache_size_in_mb: <%= p("file_cache_size_in_mb") %>
+file_cache_size_in_mb: <%= p("file_cache_size_in_mb").to_json %>
 
 # Flag indicating whether to allocate on or off heap when the sstable buffer
 # pool is exhausted, that is when it has exceeded the maximum memory
@@ -536,7 +539,7 @@ memtable_allocation_type: heap_buffers
 # and flush size and frequency. More is not better you just need enough flush writers
 # to never stall waiting for flushing to free memory.
 #
-memtable_flush_writers: <%= p("memtable_flush_writers") %>
+memtable_flush_writers: <%= p("memtable_flush_writers").to_json %>
 
 # Total space to use for change-data-capture logs on disk.
 #
@@ -572,17 +575,17 @@ index_summary_resize_interval_in_minutes: 60
 # buffers. Enable this to avoid sudden dirty buffer flushing from
 # impacting read latencies. Almost always a good idea on SSDs; not
 # necessarily on platters.
-trickle_fsync: <%= p("trickle_fsync") %>
-trickle_fsync_interval_in_kb: <%= p("trickle_fsync_interval_in_kb") %>
+trickle_fsync: <%= p("trickle_fsync").to_json %>
+trickle_fsync_interval_in_kb: <%= p("trickle_fsync_interval_in_kb").to_json %>
 
 # TCP port, for commands and data
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-storage_port: <%= p("storage_port") %>
+storage_port: <%= p("storage_port").to_json %>
 
 # SSL port, for encrypted communication.  Unused unless enabled in
 # encryption_options
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-ssl_storage_port: <%= p("ssl_storage_port") %>
+ssl_storage_port: <%= p("ssl_storage_port").to_json %>
 
 # Address or interface to bind to and tell other Cassandra nodes to connect to.
 # You _must_ change this if you want multiple nodes to be able to communicate!
@@ -596,7 +599,7 @@ ssl_storage_port: <%= p("ssl_storage_port") %>
 #
 # Setting listen_address to 0.0.0.0 is always wrong.
 #
-listen_address: <%= spec.ip %>
+listen_address: <%= spec.ip.to_json %>
 
 # Set listen_address OR listen_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.
@@ -627,10 +630,10 @@ listen_address: <%= spec.ip %>
 # Whether to start the native transport server.
 # Please note that the address on which the native transport is bound is the
 # same as the rpc_address. The port however is different and specified below.
-start_native_transport: <%= p("start_native_transport") %>
+start_native_transport: <%= p("start_native_transport").to_json %>
 # port for the CQL native transport to listen for clients on
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-native_transport_port: <%= p("native_transport_port") %>
+native_transport_port: <%= p("native_transport_port").to_json %>
 # Enabling native transport encryption in client_encryption_options allows you to either use
 # encryption for the standard port or to use a dedicated, additional port along with the unencrypted
 # standard native_transport_port.
@@ -643,12 +646,12 @@ native_transport_port: <%= p("native_transport_port") %>
 # This is similar to rpc_max_threads though the default differs slightly (and
 # there is no native_transport_min_threads, idle threads will always be stopped
 # after 30 seconds).
-native_transport_max_threads: <%= p("native_transport_max_threads") %>
+native_transport_max_threads: <%= p("native_transport_max_threads").to_json %>
 #
 # The maximum size of allowed frame. Frame (requests) larger than this will
 # be rejected as invalid. The default is 256MB. If you're changing this parameter,
 # you may want to adjust max_value_size_in_mb accordingly. This should be positive and less than 2048.
-native_transport_max_frame_size_in_mb: <%= p("native_transport_max_frame_size_in_mb") %>
+native_transport_max_frame_size_in_mb: <%= p("native_transport_max_frame_size_in_mb").to_json %>
 
 # The maximum number of concurrent client connections.
 # The default is -1, which means unlimited.
@@ -659,7 +662,7 @@ native_transport_max_frame_size_in_mb: <%= p("native_transport_max_frame_size_in
 # native_transport_max_concurrent_connections_per_ip: -1
 
 # Whether to start the thrift rpc server.
-start_rpc: <%= p("start_rpc") %>
+start_rpc: <%= p("start_rpc").to_json %>
 
 # The address or interface to bind the Thrift RPC service and native transport
 # server to.
@@ -673,7 +676,7 @@ start_rpc: <%= p("start_rpc") %>
 # set broadcast_rpc_address to a value other than 0.0.0.0.
 #
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
-rpc_address: <%= spec.ip %>
+rpc_address: <%= spec.ip.to_json %>
 
 # Set rpc_address OR rpc_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.
@@ -686,7 +689,7 @@ rpc_address: <%= spec.ip %>
 # rpc_interface_prefer_ipv6: false
 
 # port for Thrift to listen for clients on
-rpc_port: <%= p("rpc_port") %>
+rpc_port: <%= p("rpc_port").to_json %>
 
 # RPC address to broadcast to drivers and other Cassandra nodes. This cannot
 # be set to 0.0.0.0. If left blank, this will be set to the value of
@@ -695,7 +698,7 @@ rpc_port: <%= p("rpc_port") %>
 # broadcast_rpc_address: 1.2.3.4
 
 # enable or disable keepalive on rpc/native connections
-rpc_keepalive: <%= p("rpc_keepalive") %>
+rpc_keepalive: <%= p("rpc_keepalive").to_json %>
 
 # Cassandra provides two out-of-the-box options for the RPC Server:
 #
@@ -717,7 +720,7 @@ rpc_keepalive: <%= p("rpc_keepalive") %>
 #
 # Alternatively,  can provide your own RPC server by providing the fully-qualified class name
 # of an o.a.c.t.TServerFactory that can create an instance of it.
-rpc_server_type: <%= p("rpc_server_type") %>
+rpc_server_type: <%= p("rpc_server_type").to_json %>
 
 # Uncomment rpc_min|max_thread to set request pool size limits.
 #
@@ -729,8 +732,8 @@ rpc_server_type: <%= p("rpc_server_type") %>
 # encouraged to set a maximum that makes sense for you in production, but do keep in mind that
 # rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
 #
-rpc_min_threads: <%= p("rpc_min_threads") %>
-rpc_max_threads: <%= p("rpc_max_threads") %>
+rpc_min_threads: <%= p("rpc_min_threads").to_json %>
+rpc_max_threads: <%= p("rpc_max_threads").to_json %>
 
 # uncomment to set socket buffer sizes on rpc connections
 # rpc_send_buff_size_in_bytes:
@@ -753,25 +756,25 @@ rpc_max_threads: <%= p("rpc_max_threads") %>
 # internode_recv_buff_size_in_bytes:
 
 # Frame size for thrift (maximum message length).
-thrift_framed_transport_size_in_mb: <%= p("thrift_framed_transport_size_in_mb") %>
+thrift_framed_transport_size_in_mb: <%= p("thrift_framed_transport_size_in_mb").to_json %>
 
 # Set to true to have Cassandra create a hard link to each sstable
 # flushed or streamed locally in a backups/ subdirectory of the
 # keyspace data.  Removing these links is the operator's
 # responsibility.
-incremental_backups: <%= p("incremental_backups") %>
+incremental_backups: <%= p("incremental_backups").to_json %>
 
 # Whether or not to take a snapshot before each compaction.  Be
 # careful using this option, since Cassandra won't clean up the
 # snapshots for you.  Mostly useful if you're paranoid when there
 # is a data format change.
-snapshot_before_compaction: <%= p("snapshot_before_compaction") %>
+snapshot_before_compaction: <%= p("snapshot_before_compaction").to_json %>
 
 # Whether or not a snapshot is taken of the data before keyspace truncation
 # or dropping of column families. The STRONGLY advised default of true 
 # should be used to provide data safety. If you set this flag to false, you will
 # lose data on truncation or drop.
-auto_snapshot: <%= p("auto_snapshot") %>
+auto_snapshot: <%= p("auto_snapshot").to_json %>
 
 # Granularity of the collation index of rows within a partition.
 # Increase if your rows are large, or if you have a very large
@@ -783,7 +786,7 @@ auto_snapshot: <%= p("auto_snapshot") %>
 # - but, Cassandra will keep the collation index in memory for hot
 #   rows (as part of the key cache), so a larger granularity means
 #   you can cache more hot rows
-column_index_size_in_kb: <%= p("column_index_size_in_kb") %>
+column_index_size_in_kb: <%= p("column_index_size_in_kb").to_json %>
 
 # Per sstable indexed key cache entries (the collation index in memory
 # mentioned above) exceeding this size will not be held on heap.
@@ -808,7 +811,7 @@ column_index_cache_size_in_kb: 2
 # 
 # If your data directories are backed by SSD, you should increase this
 # to the number of cores.
-concurrent_compactors: <%= p("concurrent_compactors") %>
+concurrent_compactors: <%= p("concurrent_compactors").to_json %>
 
 # Throttles compaction to the given total throughput across the entire
 # system. The faster you insert data, the faster you need to compact in
@@ -839,22 +842,22 @@ sstable_preemptive_open_interval_in_mb: 50
 # inter_dc_stream_throughput_outbound_megabits_per_sec: 200
 
 # How long the coordinator should wait for read operations to complete
-read_request_timeout_in_ms: <%= p("read_request_timeout_in_ms") %>
+read_request_timeout_in_ms: <%= p("read_request_timeout_in_ms").to_json %>
 # How long the coordinator should wait for seq or index scans to complete
-range_request_timeout_in_ms: <%= p("range_request_timeout_in_ms") %>
+range_request_timeout_in_ms: <%= p("range_request_timeout_in_ms").to_json %>
 # How long the coordinator should wait for writes to complete
-write_request_timeout_in_ms: <%= p("write_request_timeout_in_ms") %>
+write_request_timeout_in_ms: <%= p("write_request_timeout_in_ms").to_json %>
 # How long the coordinator should wait for counter writes to complete
 counter_write_request_timeout_in_ms: 5000
 # How long a coordinator should continue to retry a CAS operation
 # that contends with other proposals for the same row
-cas_contention_timeout_in_ms: <%= p("cas_contention_timeout_in_ms") %>
+cas_contention_timeout_in_ms: <%= p("cas_contention_timeout_in_ms").to_json %>
 # How long the coordinator should wait for truncates to complete
 # (This can be much longer, because unless auto_snapshot is disabled
 # we need to flush first so we can snapshot before removing the data.)
-truncate_request_timeout_in_ms: <%= p("truncate_request_timeout_in_ms") %>
+truncate_request_timeout_in_ms: <%= p("truncate_request_timeout_in_ms").to_json %>
 # The default timeout for other, miscellaneous operations
-request_timeout_in_ms: <%= p("request_timeout_in_ms") %>
+request_timeout_in_ms: <%= p("request_timeout_in_ms").to_json %>
 
 # How long before a node logs slow queries. Select queries that take longer than
 # this timeout to execute, will generate an aggregated log message, so that slow queries
@@ -869,7 +872,7 @@ slow_query_log_timeout_in_ms: 500
 #
 # Warning: before enabling this property make sure to ntp is installed
 # and the times are synchronized between the nodes.
-cross_node_timeout: <%= p("cross_node_timeout") %>
+cross_node_timeout: <%= p("cross_node_timeout").to_json %>
 
 # Set keep-alive period for streaming
 # This node will send a keep-alive message periodically with this period.
@@ -881,7 +884,7 @@ cross_node_timeout: <%= p("cross_node_timeout") %>
 
 # phi value that must be reached for a host to be marked down.
 # most users should never need to adjust this.
-phi_convict_threshold: <%= p("phi_convict_threshold") %>
+phi_convict_threshold: <%= p("phi_convict_threshold").to_json %>
 
 # endpoint_snitch -- Set this to a class that implements
 # IEndpointSnitch.  The snitch has two functions:
@@ -946,14 +949,14 @@ phi_convict_threshold: <%= p("phi_convict_threshold") %>
 #
 # You can use a custom Snitch by setting this to the full class name
 # of the snitch, which will be assumed to be on your classpath.
-endpoint_snitch: <%= p("endpoint_snitch") %>
+endpoint_snitch: <%= p("endpoint_snitch").to_json %>
 
 # controls how often to perform the more expensive part of host score
 # calculation
-dynamic_snitch_update_interval_in_ms: <%= p("dynamic_snitch_update_interval_in_ms") %>
+dynamic_snitch_update_interval_in_ms: <%= p("dynamic_snitch_update_interval_in_ms").to_json %>
 # controls how often to reset all host scores, allowing a bad host to
 # possibly recover
-dynamic_snitch_reset_interval_in_ms: <%= p("dynamic_snitch_reset_interval_in_ms") %>
+dynamic_snitch_reset_interval_in_ms: <%= p("dynamic_snitch_reset_interval_in_ms").to_json %>
 # if set greater than zero and read_repair_chance is < 1.0, this will allow
 # 'pinning' of replicas to hosts in order to increase cache capacity.
 # The badness threshold will control how much worse the pinned host has to be
@@ -961,7 +964,7 @@ dynamic_snitch_reset_interval_in_ms: <%= p("dynamic_snitch_reset_interval_in_ms"
 # expressed as a double which represents a percentage.  Thus, a value of
 # 0.2 means Cassandra would continue to prefer the static snitch values
 # until the pinned host was 20% worse than the fastest.
-dynamic_snitch_badness_threshold: <%= p("dynamic_snitch_badness_threshold") %>
+dynamic_snitch_badness_threshold: <%= p("dynamic_snitch_badness_threshold").to_json %>
 
 # request_scheduler -- Set this to a class that implements
 # RequestScheduler, which will schedule incoming client requests
@@ -974,7 +977,7 @@ dynamic_snitch_badness_threshold: <%= p("dynamic_snitch_badness_threshold") %>
 # client requests to a node with a separate queue for each
 # request_scheduler_id. The scheduler is further customized by
 # request_scheduler_options as described below.
-request_scheduler: <%= p("request_scheduler") %>
+request_scheduler: <%= p("request_scheduler").to_json %>
 
 # Scheduler Options vary based on the type of scheduler
 #
@@ -1029,11 +1032,11 @@ request_scheduler: <%= p("request_scheduler") %>
 # http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
 #
 server_encryption_options:
-    internode_encryption: <%= p("internode_encryption_mode") %>
-    keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
-    keystore_password: <%= p("keystore_password") %>
-    truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
-    truststore_password: <%= p("keystore_password") %>
+    internode_encryption: <%= p("internode_encryption_mode").to_json %>
+    keystore: <%= "/var/vcap/jobs/cassandra/config/certs/#{spec.ip}_cassandra.keystore".to_json %>
+    keystore_password: <%= p("keystore_password").to_json %>
+    truststore: <%= "/var/vcap/jobs/cassandra/config/certs/#{spec.ip}_cassandra.truststore".to_json %>
+    truststore_password: <%= p("keystore_password").to_json %>
     protocol: TLS
     # More advanced defaults below:
     # protocol: TLS
@@ -1045,16 +1048,16 @@ server_encryption_options:
 
 # enable or disable client/server encryption.
 client_encryption_options:
-    enabled: <%= p("client_encryption.enabled") %>
+    enabled: <%= p("client_encryption.enabled").to_json %>
     # If enabled and optional is set to true encrypted and unencrypted connections are handled.
     optional: false
-    keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
-    keystore_password: <%= p("keystore_password") %>
+    keystore: <%= "/var/vcap/jobs/cassandra/config/certs/#{spec.ip}_cassandra.keystore".to_json %>
+    keystore_password: <%= p("keystore_password").to_json %>
 
-    require_client_auth: <%= p("client_encryption.require_client_auth") %>
+    require_client_auth: <%= p("client_encryption.require_client_auth").to_json %>
     # Set trustore and truststore_password if require_client_auth is true
-    truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
-    truststore_password: <%= p("keystore_password") %>
+    truststore: <%= "/var/vcap/jobs/cassandra/config/certs/#{spec.ip}_cassandra.truststore".to_json %>
+    truststore_password: <%= p("keystore_password").to_json %>
 
     # More advanced defaults below:
     protocol: TLS
@@ -1074,13 +1077,13 @@ client_encryption_options:
 #
 # none
 #   nothing is compressed.
-internode_compression: <%= p("internode_compression") %>
+internode_compression: <%= p("internode_compression").to_json %>
 
 # Enable or disable tcp_nodelay for inter-dc communication.
 # Disabling it will result in larger (but fewer) network packets being sent,
 # reducing overhead from the TCP protocol itself, at the cost of increasing
 # latency if you block for cross-datacenter responses.
-inter_dc_tcp_nodelay: <%= p("inter_dc_tcp_nodelay") %>
+inter_dc_tcp_nodelay: <%= p("inter_dc_tcp_nodelay").to_json %>
 
 # TTL for different trace types used during logging of the repair process.
 tracetype_query_ttl: 86400
@@ -1151,8 +1154,8 @@ transparent_data_encryption_options:
 # Adjust the thresholds here if you understand the dangers and want to
 # scan more tombstones anyway.  These thresholds may also be adjusted at runtime
 # using the StorageService mbean.
-tombstone_warn_threshold: <%= p("tombstone_warn_threshold") %>
-tombstone_failure_threshold: <%= p("tombstone_failure_threshold") %>
+tombstone_warn_threshold: <%= p("tombstone_warn_threshold").to_json %>
+tombstone_failure_threshold: <%= p("tombstone_failure_threshold").to_json %>
 
 # Log WARN on any multiple-partition batch size exceeding this value. 5kb per batch by default.
 # Caution should be taken on increasing the size of this threshold as it can lead to node instability.
@@ -1175,7 +1178,7 @@ gc_warn_threshold_in_ms: 1000
 # Maximum size of any value in SSTables. Safety measure to detect SSTable corruption
 # early. Any value size larger than this threshold will result into marking an SSTable
 # as corrupted. This should be positive and less than 2048.
-max_value_size_in_mb: <%= p("max_value_size_in_mb") %>
+max_value_size_in_mb: <%= p("max_value_size_in_mb").to_json %>
 
 # Back-pressure settings #
 # If enabled, the coordinator will apply the back-pressure strategy specified below to each mutation

--- a/jobs/cassandra/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra/templates/config/cassandra.yaml.erb
@@ -1175,7 +1175,7 @@ gc_warn_threshold_in_ms: 1000
 # Maximum size of any value in SSTables. Safety measure to detect SSTable corruption
 # early. Any value size larger than this threshold will result into marking an SSTable
 # as corrupted. This should be positive and less than 2048.
-# max_value_size_in_mb: 256
+max_value_size_in_mb: <%= p("max_value_size_in_mb") %>
 
 # Back-pressure settings #
 # If enabled, the coordinator will apply the back-pressure strategy specified below to each mutation

--- a/jobs/cassandra/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra/templates/config/cassandra.yaml.erb
@@ -70,7 +70,7 @@ max_hints_delivery_threads: <%= p("max_hints_delivery_threads") %>
 
 # Directory where Cassandra should store hints.
 # If not set, the default directory is $CASSANDRA_HOME/data/hints.
-hints_directory: <%= p("persistent_directory") %>/<%= p("cluster_name") %>/hint
+hints_directory: /var/vcap/store/cassandra/<%= p("cluster_name") %>/hint
 
 # How often hints should be flushed from the internal buffers to disk.
 # Will *not* trigger fsync.
@@ -188,12 +188,12 @@ partitioner: <%= p("partitioner") %>
 # the configured compaction strategy.
 # If not set, the default directory is $CASSANDRA_HOME/data/data.
 data_file_directories:
-    - <%= p("persistent_directory") %>/<%= p("cluster_name") %>/data
+    - /var/vcap/store/cassandra/<%= p("cluster_name") %>/data
 
 # commit log.  when running on magnetic HDD, this should be a
 # separate spindle than the data directories.
 # If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
-commitlog_directory: <%= p("persistent_directory") %>/<%= p("cluster_name") %>/commitlog
+commitlog_directory: /var/vcap/store/cassandra/<%= p("cluster_name") %>/commitlog
 
 # Enable / disable CDC functionality on a per-node basis. This modifies the logic used
 # for write path allocation rejection (standard: never reject. cdc: reject Mutation
@@ -365,7 +365,7 @@ counter_cache_save_period: 7200
 
 # saved caches
 # If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
-saved_caches_directory: <%= p("persistent_directory") %>/<%= p("cluster_name") %>/saved_caches
+saved_caches_directory: /var/vcap/store/cassandra/<%= p("cluster_name") %>/saved_caches
 
 # commitlog_sync may be either "periodic" or "batch." 
 # 

--- a/jobs/cassandra/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra/templates/config/cassandra.yaml.erb
@@ -1031,9 +1031,9 @@ request_scheduler: <%= p("request_scheduler") %>
 server_encryption_options:
     internode_encryption: <%= p("internode_encryption_mode") %>
     keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
-    keystore_password: <%= p("cass_KSP") %>
+    keystore_password: <%= p("keystore_password") %>
     truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
-    truststore_password: <%= p("cass_KSP") %>
+    truststore_password: <%= p("keystore_password") %>
     protocol: TLS
     # More advanced defaults below:
     # protocol: TLS
@@ -1049,12 +1049,12 @@ client_encryption_options:
     # If enabled and optional is set to true encrypted and unencrypted connections are handled.
     optional: false
     keystore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.keystore
-    keystore_password: <%= p("cass_KSP") %>
+    keystore_password: <%= p("keystore_password") %>
 
     require_client_auth: <%= p("client_encryption.require_client_auth") %>
     # Set trustore and truststore_password if require_client_auth is true
     truststore: /var/vcap/jobs/cassandra/config/certs/<%=spec.ip%>_cassandra.truststore
-    truststore_password: <%= p("cass_KSP") %>
+    truststore_password: <%= p("keystore_password") %>
 
     # More advanced defaults below:
     protocol: TLS

--- a/jobs/cassandra/templates/config/cassandra.yaml.erb
+++ b/jobs/cassandra/templates/config/cassandra.yaml.erb
@@ -128,7 +128,7 @@ role_manager: CassandraRoleManager
 # after the period specified here, become eligible for (async) reload.
 # Defaults to 2000, set to 0 to disable caching entirely.
 # Will be disabled automatically for AllowAllAuthenticator.
-roles_validity_in_ms: 2000
+roles_validity_in_ms: <%= p("permissions_validity_in_ms").to_json %>
 
 # Refresh interval for roles cache (if enabled).
 # After this interval, cache entries become eligible for refresh. Upon next
@@ -161,7 +161,7 @@ permissions_validity_in_ms: <%= p("permissions_validity_in_ms") %>
 # underlying table, it may not  bring a significant reduction in the
 # latency of individual authentication attempts.
 # Defaults to 2000, set to 0 to disable credentials caching.
-credentials_validity_in_ms: 2000
+credentials_validity_in_ms: <%= p("credentials_validity_in_ms") %>
 
 # Refresh interval for credentials cache (if enabled).
 # After this interval, cache entries become eligible for refresh. Upon next

--- a/jobs/cassandra/templates/config/cqlshrc.erb
+++ b/jobs/cassandra/templates/config/cqlshrc.erb
@@ -1,6 +1,6 @@
 [authentication]
 username = cassandra
-password = <%= p("cass_pwd") %>
+password = <%= p("cassandra_password") %>
 
 [connection]
 hostname = <%= spec.ip %>

--- a/jobs/cassandra/templates/config/jvm.options.erb
+++ b/jobs/cassandra/templates/config/jvm.options.erb
@@ -7,6 +7,13 @@
 # - only static flags are accepted (no variables or parameters)           #
 # - dynamic flags will be appended to these on cassandra-env              #
 ###########################################################################
+<%
+  require "shellwords"
+
+  def esc(x)
+      Shellwords.shellescape(x)
+  end
+-%>
 
 ######################
 # STARTUP PARAMETERS #
@@ -254,5 +261,5 @@
 -Djava.io.tmpdir=/var/vcap/data/cassandra/jna-tmp
 
 <% if p('jmx_exporter_enabled') %>
--javaagent:/var/vcap/packages/cassandra/lib/jmx_prometheus_javaagent-0.1.0.jar=<%= p('jmx_exporter_port') %>:/var/vcap/jobs/cassandra/conf/jmx_exporter.yml
+-javaagent:/var/vcap/packages/cassandra/lib/jmx_prometheus_javaagent-0.1.0.jar=<%= esc(p('jmx_exporter_port')) %>:/var/vcap/jobs/cassandra/conf/jmx_exporter.yml
 <% end %>

--- a/jobs/cassandra/templates/ssl/cassandradb.ca.erb
+++ b/jobs/cassandra/templates/ssl/cassandradb.ca.erb
@@ -1,1 +1,0 @@
-<%= p("cassDbCertificate.ca") -%>

--- a/jobs/cassandra/templates/ssl/cassandradb.pem.erb
+++ b/jobs/cassandra/templates/ssl/cassandradb.pem.erb
@@ -1,2 +1,0 @@
-<%= p("cassDbCertificate.certificate") -%>
-<%= p("cassDbCertificate.private_key") -%>

--- a/jobs/cassandra/templates/ssl2/gen_keystore_client.sh
+++ b/jobs/cassandra/templates/ssl2/gen_keystore_client.sh
@@ -8,7 +8,7 @@ export PATH=$PATH:$JAVA_HOME/bin:.
 
 export HOST_NAME1=`hostname -I`
 export HOST_NAME=${HOST_NAME1//[[:space:]]}
-export STOREPASS="<%= p("cass_KSP") %>"
+export STOREPASS="<%= p("keystore_password") %>"
 export KEYPASS=$STOREPASS
 keytool -genkeypair -keyalg RSA -alias ${HOST_NAME} -keystore ${HOST_NAME}.jks -storepass $STOREPASS -keypass $KEYPASS -validity 3650 -keysize 2048 -dname "CN=${HOST_NAME}, OU=TestCluster, O=Orange, L=Lyon, S=FR, C=FR"
 

--- a/jobs/cassandra/templates/ssl3/gen_keystore_client.sh
+++ b/jobs/cassandra/templates/ssl3/gen_keystore_client.sh
@@ -17,7 +17,7 @@ export CLUSTER_NAME="<%= p("cluster_name") %>"
 export CLUSTER_PUBLIC_CERT="$KEY_STORE_PATH/${HOST_NAME}_CLUSTER_${CLUSTER_NAME}_PUBLIC.cer"
 export CLIENT_PUBLIC_CERT="$KEY_STORE_PATH/${HOST_NAME}_CLIENT_${CLUSTER_NAME}_PUBLIC.cer"
 
-export STOREPASS="<%= p("cass_KSP") %>"
+export STOREPASS="<%= p("keystore_password") %>"
 export KEYPASS=$STOREPASS
 export PASSWORD=$KEYPASS
 


### PR DESCRIPTION
Here we reviewed config properties, evaluate relevancy, and possibly remove unnecessary.

- Switch the default values for `max_heap_size` and `heap_newsize` to those suggested by the Cassandra distrib
- [breaking] Rename `cass_pwd` and `cass_KSP`
- [breaking] Remove `persistent_directory`
- Compute reasonable default values when possible and relevant.
- Add missing configuration for `$CASSANDRA_HEAPDUMP_DIR`
