### PR TITLE
Implement a new topology mapping

### DIFF
--- a/deployment/cassandra.yml
+++ b/deployment/cassandra.yml
@@ -29,6 +29,11 @@ instance_groups:
             private_key: ((cassandra_certificate_seeds.private_key))
             certificate: ((cassandra_certificate_seeds.certificate))
           keystore_password: ((cassandra_key_store_pass))
+          bosh_to_cassandra_topology_mapping:
+            z1:      { dc: DC1, rack: RAC1 }
+            z2:      { dc: DC1, rack: RAC2 }
+            z3:      { dc: DC1, rack: RAC3 }
+            default: { dc: DC1, rack: RAC3 }
     stemcell: *trusty_stemcell
     vm_type: &cassandra_vm_type default
     persistent_disk_type: &cassandra_persistent_disk_type 5GB

--- a/deployment/cassandra.yml
+++ b/deployment/cassandra.yml
@@ -12,6 +12,7 @@ instance_groups:
           cassandra: { as: &cassandra_seeds_link cassandra_seeds_list }
         consumes:
           seeds: { from: *cassandra_seeds_link }
+          non_seeds: { from: *cassandra_non_seeds_link }
         properties: &cassandra_properties
           cluster_name: &cassandra_cluster_name cluster
           num_tokens: 256
@@ -42,8 +43,11 @@ instance_groups:
     jobs:
       - name: cassandra
         release: *cassandra_release
+        provides:
+          cassandra: { as: &cassandra_non_seeds_link cassandra_non_seeds_list }
         consumes:
           seeds: { from: *cassandra_seeds_link }
+          non_seeds: { from: *cassandra_non_seeds_link }
         properties: *cassandra_properties
     stemcell: *trusty_stemcell
     vm_type: *cassandra_vm_type

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -572,24 +572,6 @@ properties:
       - 'CloudstackSnitch'
         Use this snitch for Apache Cloudstack environments.
     default: PropertyFileSnitch
-  topology:
-    description: |
-      The topology (in Java Properties file syntax) to be injected in the
-      'cassandra-topology.properties' file. Directives are expressed as an
-      array, the elements of which will be joined with newlines ('\n'). Thus,
-      each array elements can be made of one or many Java Properties,
-      depending on what fits best for your use-case.
-
-      The template 'cassandra-topology.properties' file includes a
-      'default=DC1:RAC1' directive that applies to all unknown nodes.
-    default: []
-    example:
-    - |
-      192.168.1.100=DC1:RAC1
-      192.168.2.200=DC2:RAC2
-    - |
-      10.0.0.11=DC1:RAC1
-      10.0.0.12=DC1:RAC2
   bosh_to_cassandra_topology_mapping:
     description: |
       Maps BOSH Availability Zone (AZs) to Cassandra “DCs” (Data Centers) and

--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -18,6 +18,8 @@ provides:
 consumes:
   - name: seeds
     type: cassandra
+  - name: non_seeds
+    type: cassandra
 
 templates:
   bin/pre-start.sh: bin/pre-start
@@ -588,6 +590,39 @@ properties:
     - |
       10.0.0.11=DC1:RAC1
       10.0.0.12=DC1:RAC2
+  bosh_to_cassandra_topology_mapping:
+    description: |
+      Maps BOSH Availability Zone (AZs) to Cassandra “DCs” (Data Centers) and
+      “Racks”.
+
+      To understand the notion of “Rack”, you need to know that the
+      replication strategy implemented in Cassandra does its best not to have
+      more than one replica on the same “Rack”, as informed by the snitch.
+      (See also the 'endpoint_snitch' configuration property for more
+      details.)
+
+      To understand the notion of “DC”, you need to know that Cassandra
+      implements different transfer strategies when nodes are not in the same
+      Data Center and thus the latency is higher between them.
+
+      Depending on your BOSH setup, a BOSH Availability Zone can be mapped to
+      different zones (the usual setup) or different Data Centers (the more
+      recent multi-CPI setup).
+
+      The mapping you give here in this configuration property allows you to
+      set a specific “DC” and “Rack” location to each BOSH availability zone.
+
+      This mapping will be used to polulate the 'cassandra-topology.properties'
+      (used by 'PropertyFileSnitch') and 'cassandra-rackdc.properties' (used
+      by 'GossipingPropertyFileSnitch'). See the 'endpoint_snitch'
+      configuration property for more details about snitch implementations.
+    default: {}
+    example:
+      z1: { dc: DC1, rack: RAC1 }
+      z2: { dc: DC1, rack: RAC2 }
+      z3: { dc: DC2, rack: RAC1 }
+      z4: { dc: DC2, rack: RAC2 }
+      default: { dc: DC2, rack: RAC1 }
   dynamic_snitch_update_interval_in_ms:
     description: |
       The number of milliseconds between Cassandra's calculation of node

--- a/jobs/cassandra/templates/config/cassandra-rackdc.properties.erb
+++ b/jobs/cassandra/templates/config/cassandra-rackdc.properties.erb
@@ -16,8 +16,21 @@
 
 # These properties are used with GossipingPropertyFileSnitch and will
 # indicate the rack and dc for this node
-dc=DC1
-rack=RAC1
+<%
+    dc = "DC1"
+    rack = "RAC1"
+    if_p('bosh_to_cassandra_topology_mapping') do |topology_map|
+        if topology_map[spec.az] != nil
+            dc = topology_map[spec.az]['dc']
+            rack = topology_map[spec.az]['rack']
+        elsif topology_map['default'] != nil
+            dc = topology_map['default']['dc']
+            rack = topology_map['default']['rack']
+        end
+    end
+%>
+dc=<%= dc %>
+rack=<%= rack %>
 
 # Add a suffix to a datacenter name. Used by the Ec2Snitch and Ec2MultiRegionSnitch
 # to append a string to the EC2 region name.

--- a/jobs/cassandra/templates/config/cassandra-topology.properties.erb
+++ b/jobs/cassandra/templates/config/cassandra-topology.properties.erb
@@ -15,9 +15,43 @@
 # limitations under the License.
 
 # Cassandra Node IP=Data Center:Rack
-<% (p("topology")).each do |topology| %>
-<%= topology %>
-<% end %>
+<%
+    def to_topology_line(instance, topology_map)
+        dc = "DC1"
+        rack = "RAC1"
+        if topology_map[instance.az] != nil
+            dc = topology_map[instance.az]['dc']
+            rack = topology_map[instance.az]['rack']
+        elsif topology_map['default'] != nil
+            dc = topology_map['default']['dc']
+            rack = topology_map['default']['rack']
+        end
+        return "#{instance.address}=#{dc}:#{rack}"
+    end
+
+    topology = []
+    if_p('bosh_to_cassandra_topology_mapping') do |topology_map|
+        link('seeds').instances.each do |instance|
+            topology << to_topology_line(instance, topology_map)
+        end
+        link('non_seeds').instances.each do |instance|
+            topology << to_topology_line(instance, topology_map)
+        end
+    end
+%>
+<% topology.each do |topology_line| -%>
+<%= topology_line %>
+<% end -%>
 
 # default for unknown nodes
-default=DC1:RAC1
+<%
+    dc = "DC1"
+    rack = "RAC1"
+    if_p('bosh_to_cassandra_topology_mapping') do |topology_map|
+        if topology_map['default'] != nil
+            dc = topology_map['default']['dc']
+            rack = topology_map['default']['rack']
+        end
+    end
+-%>
+default=<%= "#{dc}:#{rack}" %>


### PR DESCRIPTION
This is a development of the idea for a “bosh-to-cassandra” topology mapping.

Still TODO:
- Document that going from no Bosh AZs to some Bosh AZs is a very disruptive operation that should be run with great care (i.e. add new instance group with AZs, have it sync, then remove old instance groups with no AZs)