### PR TITLE
Support automatic node decommissioning uppon cluster 'scale-in' operation

### DIFF
--- a/jobs/cassandra/spec
+++ b/jobs/cassandra/spec
@@ -23,6 +23,7 @@ templates:
   bin/pre-start.sh: bin/pre-start
   bpm.yml: config/bpm.yml
   bpm-prestart: bpm-prestart
+  bin/drain: bin/drain
   bin/cassandra_ctl: bin/cassandra_ctl
   bin/monit_debugger: bin/monit_debugger
   data/properties.sh.erb: data/properties.sh

--- a/jobs/cassandra/templates/bin/drain
+++ b/jobs/cassandra/templates/bin/drain
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+exec 3>&1
+exec 1>> /var/vcap/sys/log/cassandra/drain.stdout.log
+exec 2>> /var/vcap/sys/log/cassandra/drain.stderr.log
+
+output_for_bosh() {
+    exit_code=$?
+
+    if [ $exit_code -eq 0 ]; then
+        echo "$(date +%F_%T): cassandra member removed"
+    else
+        echo "$(date +%F_%T): drain failed"
+    fi
+
+    echo $exit_code >&3
+}
+
+trap output_for_bosh EXIT
+
+if echo "${BOSH_JOB_NEXT_STATE}" | grep -Fq '"persistent_disk":0'; then
+    echo "$(date +%F_%T): detected 'scale-in' condition, decommissioning current node"
+    /var/vcap/jobs/cassandra/bin/nodetool decommission
+fi


### PR DESCRIPTION
This work adds a `drain` script that properly detects cluster _scale-in_ operations and take action, calling `nodetool decommission` to gracefully remove the current node from the cluster.

Good to know: when scaling in to 1 node, this node config will be re-rendered, so the node will stop and start. Thus, a downtime will be experienced.

Still TODO:
1. Document this downtime as a caveat
2. Document that the release supports both scale-out and scale-in operations
